### PR TITLE
SRV records use hostnames instead of IP addresses.

### DIFF
--- a/records/generator.go
+++ b/records/generator.go
@@ -261,7 +261,7 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string
 
 					// FIXME - 3 nested loops
 					for s := 0; s < len(sports); s++ {
-						var srvhost string = host + ":" + sports[s]
+						var srvhost string = tname + "." + fname + "." + domain + ":" + sports[s]
 
 						tcp := "_" + tname + "._tcp." + tail
 						udp := "_" + tname + "._udp." + tail
@@ -311,7 +311,7 @@ func (rg *RecordGenerator) masterRecord(listener string, domain string, masters 
 
                 tcp := "_master._tcp." + domain + "."
                 udp := "_master._udp." + domain + "."
-                host := ip + ":" + port
+                host := "master." + domain + ":" + port
                 rg.insertRR(tcp, host, "SRV")
                 rg.insertRR(udp, host, "SRV")
          } 


### PR DESCRIPTION
So far, we have used IP addresses in SRV records. While this is cool as it saves one DNS lookup, to be correct we should use "target: the canonical hostname of the machine providing the service, ending in a dot." 