### PR TITLE
Support multiple listeners

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -6,6 +6,6 @@
   "port": 8053,
   "resolvers": ["8.8.8.8"],
   "timeout": 5,
-  "listener": "0.0.0.0",
+  "listeners": [ "0.0.0.0" ],
   "email": "root.mesos-dns.mesos"
 }

--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -17,7 +17,7 @@ The configuration file should include the following fields:
   "port": 53,
   "resolvers": ["169.254.169.254"],
   "timeout": 5, 
-  "listener": "10.101.160.16",
+  "listeners": [ "10.101.160.16" ],
   "email": "root.mesos-dns.mesos"
 }
 ```
@@ -37,6 +37,6 @@ The configuration file should include the following fields:
  
 `timeout` is the timeout threshold, in seconds, for connections and requests to external DNS requests. The default value is 5 seconds. 
 
-`listener` is the IP address of Mesos-DNS. In SOA replies, Mesos-DNS identifies hostname `mesos-dns.domain` as the primary nameserver for the domain. It uses this IP address in an A record for `mesos-dns.domain`. The default value is "0.0.0.0", which instructs Mesos-DNS to create an A record for every IP address associated with a network interface on the server that runs the Mesos-DNS process. 
+`listeners` is a list of IP addresses for of Mesos-DNS to listen on. In SOA replies, Mesos-DNS identifies hostname `mesos-dns.domain` as the primary nameserver for the domain. It uses this IP address in an A record for `mesos-dns.domain`. The default value is "0.0.0.0", which instructs Mesos-DNS to create an A record for every IP address associated with a network interface on the server that runs the Mesos-DNS process.
 
 `email` is the email address of the Mesos domain name administrator. It is associated with the SOA record for the Mesos domain. The format is `mailbox-name.domain`, using a `.` instead of `@`. For example, if the email address is `root@mesos-dns.mesos`, the `email` field should be `root.mesos-dns.mesos`. The default value is `root.mesos-dns.mesos`.

--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -23,7 +23,7 @@ The configuration file should include the following fields:
 ```
 
 
-`masters` is a comma separated list with the IP address and port number for the master(s) in the Mesos cluster. Mesos-DNS will automatically find the leading master at any point in order to retrieve state about running tasks. If there is no leading master or the leading master is not responsive, Mesos-DNS will continue serving DNS requests based on stale information about running tasks. The `masters` field is required. 
+`masters` is a list with the IP address and port number for the master(s) in the Mesos cluster. Mesos-DNS will automatically find the leading master at any point in order to retrieve state about running tasks. If there is no leading master or the leading master is not responsive, Mesos-DNS will continue serving DNS requests based on stale information about running tasks. The `masters` field is required.
 
 `refreshSeconds` is the frequency at which Mesos-DNS updates DNS records based on information retrieved from the Mesos master. The default value is 60 seconds. 
 
@@ -33,7 +33,7 @@ The configuration file should include the following fields:
 
 `port` is the port number that Mesos-DNS monitors for incoming DNS requests from slaves. Requests can be sent over TCP or UDP. We recommend you use port `53` as several applications assume that the DNS server listens to this port. The default value is `53`.
 
-`resolvers` is a comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the `domain`. We ***recommend*** that you list the nameservers specified in the `/etc/resolv.conf` on the server Mesos-DNS is running. Alternatively, you can list `8.8.8.8`, which is the [Google public DNS](https://developers.google.com/speed/public-dns/) address. The `resolvers` field is required. 
+`resolvers` is a list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the `domain`. We ***recommend*** that you list the nameservers specified in the `/etc/resolv.conf` on the server Mesos-DNS is running. Alternatively, you can list `8.8.8.8`, which is the [Google public DNS](https://developers.google.com/speed/public-dns/) address. The `resolvers` field is required.
  
 `timeout` is the timeout threshold, in seconds, for connections and requests to external DNS requests. The default value is 5 seconds. 
 

--- a/records/config.go
+++ b/records/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	Mname string
 
 	// ListenAddr is the server listener address
-	Listener string
+	Listeners []string
 }
 
 // SetConfig instantiates a Config struct read in from config.json
@@ -61,7 +61,7 @@ func SetConfig(cjson string) (c Config) {
 		Timeout:        5,
 		Email:          "root.mesos-dns.mesos",
 		Resolvers:      []string{"8.8.8.8"},
-		Listener:       "0.0.0.0",
+		Listeners:      []string{"0.0.0.0"},
 	}
 
 	usr, _ := user.Current()
@@ -99,7 +99,7 @@ func SetConfig(cjson string) (c Config) {
 		c.Email = c.Email + "."
 	}
 
-    c.Domain = strings.ToLower(c.Domain)
+	c.Domain = strings.ToLower(c.Domain)
 	c.Mname = "mesos-dns." + c.Domain + "."
 
 	logging.Verbose.Println("Mesos-DNS configuration:")
@@ -109,7 +109,7 @@ func SetConfig(cjson string) (c Config) {
 	logging.Verbose.Println("   - Domain: " + c.Domain)
 	logging.Verbose.Println("   - Port: ", c.Port)
 	logging.Verbose.Println("   - Timeout: ", c.Timeout)
-	logging.Verbose.Println("   - Listener: " + c.Listener)
+	logging.Verbose.Println("   - Listeners: " + strings.Join(c.Listeners, ", "))
 	logging.Verbose.Println("   - Resolvers: " + strings.Join(c.Resolvers, ", "))
 	logging.Verbose.Println("   - Email: " + c.Email)
 	logging.Verbose.Println("   - Mname: " + c.Mname)

--- a/records/generator.go
+++ b/records/generator.go
@@ -212,7 +212,7 @@ func (rg *RecordGenerator) ParseState(config Config) {
 		return
 	}
 
-	rg.InsertState(sj, config.Domain, config.Mname, config.Listener, config.Masters)
+	rg.InsertState(sj, config.Domain, config.Mname, config.Listeners, config.Masters)
 }
 
 // cleanName sanitizes invalid characters
@@ -233,7 +233,7 @@ func stripInvalid(tname string) string {
 }
 
 // InsertState transforms a StateJSON into RecordGenerator RRs
-func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string, listener string, masters []string) error {
+func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string, listeners []string, masters []string) error {
 	rg.Slaves = sj.Slaves
 
 	rg.SRVs = make(rrs)
@@ -279,9 +279,10 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string
 		}
 	}
 
-	rg.listenerRecord(listener, mname)
-	rg.masterRecord(listener, domain, masters)
-
+	for _, listener := range listeners {
+		rg.listenerRecord(listener, mname)
+		rg.masterRecord(listener, domain, masters)
+	}
 	return nil
 }
 

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -141,7 +141,7 @@ func TestInsertState(t *testing.T) {
 
 	masters := []string{"144.76.157.37:5050"}
 	rg := RecordGenerator{}
-	rg.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters)
+	rg.InsertState(sj, "mesos", "mesos-dns.mesos.", []string{"127.0.0.1"}, masters)
 
 	// ensure we are only collecting running tasks
 	_, ok := rg.SRVs["_poseidon._tcp.marathon-0.6.0.mesos."]

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -325,15 +325,19 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 
 // Serve starts a dns server for net protocol
 func (res *Resolver) Serve(net string) {
-	server := &dns.Server{
-		Addr:       res.Config.Listener + ":" + strconv.Itoa(res.Config.Port),
-		Net:        net,
-		TsigSecret: nil,
-	}
+	for _, listener := range res.Config.Listeners {
+		server := &dns.Server{
+			Addr:       listener + ":" + strconv.Itoa(res.Config.Port),
+			Net:        net,
+			TsigSecret: nil,
+		}
 
-	err := server.ListenAndServe()
-	if err != nil {
-		logging.Error.Printf("Failed to setup "+net+" server: %s\n", err.Error())
+		go func() {
+			err := server.ListenAndServe()
+			if err != nil {
+				logging.Error.Printf("Failed to setup %s server on %s: %s\n", net, listener, err.Error())
+			}
+		}()
 	}
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -85,7 +85,7 @@ func fakeDNS(port int) (Resolver, error) {
 		Port:      port,
 		Domain:    "mesos",
 		Resolvers: records.GetLocalDNS(),
-		Listener:  "127.0.0.1",
+		Listeners: []string{"127.0.0.1"},
 		Email:     "root.mesos-dns.mesos.",
 		Mname:     "mesos-dns.mesos.",
 	}
@@ -103,7 +103,7 @@ func fakeDNS(port int) (Resolver, error) {
 
 	masters := []string{"144.76.157.37:5050"}
 	res.rs = records.RecordGenerator{}
-	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters)
+	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", []string{"127.0.0.1"}, masters)
 
 	return res, nil
 }


### PR DESCRIPTION
This changes the listener parameter to listeners list parameter.
mesos-dns will try to bind each address and also use them for the
generated records like the SOA and mesos-dns records.

This closes #87.