### PR TITLE
Command Line flags and Evironment Varaiable

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,10 +7,9 @@ import (
 )
 
 var (
-	VerboseFlag bool
-	Info        *log.Logger
-	Verbose     *log.Logger
-	Error       *log.Logger
+	Info    *log.Logger
+	Verbose *log.Logger
+	Error   *log.Logger
 )
 
 type LogOut struct {
@@ -32,18 +31,12 @@ func PrintCurLog() {
 	Verbose.Printf("%+v\n", CurLog)
 }
 
-// setupLogs provides the following logs
-// Info = stdout
-// Verbose = optional verbosity
-// Error = stderr
-func SetupLogs() {
+func init() {
 	Info = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-
-	if VerboseFlag {
-		Verbose = log.New(os.Stdout, "VERBOSE: ", log.Ldate|log.Ltime|log.Lshortfile)
-	} else {
-		Verbose = log.New(ioutil.Discard, "VERBOSE: ", log.Ldate|log.Ltime|log.Lshortfile)
-	}
-
+	Verbose = log.New(ioutil.Discard, "VERBOSE: ", log.Ldate|log.Ltime|log.Lshortfile)
 	Error = log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+}
+
+func VerboseEnable() {
+	Verbose = log.New(os.Stdout, "VERBOSE: ", log.Ldate|log.Ltime|log.Lshortfile)
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,28 +11,67 @@ import (
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/resolver"
 
+	"github.com/codegangsta/cli"
 	"github.com/miekg/dns"
 )
 
 func main() {
+	app := cli.NewApp()
+	app.Name = "mesos-dns"
+	// From version.go can also be set via -ldflags
+	app.Version = version
+	app.Usage = "DNS-based service discovery for Mesos"
+	app.Flags = records.Flags("MESOS_DNS")
+	app.Action = func(c *cli.Context) {
+
+		conf := records.New()
+
+		// If config file load the json
+		if c.String("jsonconfig") != "" {
+			logging.Info.Println("Loading config: ", c.String("jsonconfig"))
+			if err := conf.LoadFromFile(c.String("jsonconfig")); err != nil {
+				logging.Error.Println("Loading File", c.String("jsonconfig"), "error", err)
+				os.Exit(1)
+			}
+		}
+		// Command line args and enironmnet override defaults, and jsonconfig
+		if err := conf.LoadFromContext(c); err != nil {
+			fmt.Println("Error Loading: ", err)
+			os.Exit(1)
+		}
+		// Verify the config
+		if err := conf.Check(); err != nil {
+			fmt.Println("Error in Config: ", err)
+			os.Exit(1)
+		}
+
+		if conf.Verbose {
+			logging.VerboseEnable()
+		}
+		logging.Verbose.Println("Mesos-DNS configuration:")
+		logging.Verbose.Println("   - Masters: " + strings.Join(conf.Masters, ", "))
+		logging.Verbose.Println("   - RefreshSeconds: ", conf.RefreshSeconds)
+		logging.Verbose.Println("   - TTL: ", conf.TTL)
+		logging.Verbose.Println("   - Domain: " + conf.Domain)
+		logging.Verbose.Println("   - Port: ", conf.Port)
+		logging.Verbose.Println("   - Timeout: ", conf.Timeout)
+		logging.Verbose.Println("   - Listener: " + conf.Listener)
+		logging.Verbose.Println("   - Resolvers: " + strings.Join(conf.Resolvers, ", "))
+		logging.Verbose.Println("   - Email: " + conf.Email)
+		logging.Verbose.Println("   - Mname: " + conf.Mname)
+
+		Server(conf)
+
+	}
+	app.Run(os.Args)
+
+}
+
+func Server(c records.Config) {
 	var wg sync.WaitGroup
 	var resolver resolver.Resolver
 
-	versionFlag := false
-
-	cjson := flag.String("config", "config.json", "location of configuration file (json)")
-	flag.BoolVar(&logging.VerboseFlag, "v", false, "increase the verbosity level")
-	flag.BoolVar(&versionFlag, "version", false, "output the version")
-	flag.Parse()
-
-	if versionFlag {
-		fmt.Println(version)
-		os.Exit(0)
-	}
-
-	logging.SetupLogs()
-
-	resolver.Config = records.SetConfig(*cjson)
+	resolver.Config = c
 
 	// reload the first time
 	resolver.Reload()

--- a/records/config.go
+++ b/records/config.go
@@ -2,14 +2,19 @@ package records
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mesosphere/mesos-dns/logging"
+
+	"github.com/codegangsta/cli"
 	"github.com/miekg/dns"
 )
 
@@ -17,43 +22,117 @@ import (
 type Config struct {
 
 	// Mesos master(s): a list of IP:port/zk pairs for one or more Mesos masters
-	Masters []string
+	Masters []string `json:"masters"`
 
 	// Refresh frequency: the frequency in seconds of regenerating records (default 60)
-	RefreshSeconds int
+	RefreshSeconds int `json:"refreshseconds"`
 
 	// TTL: the TTL value used for SRV and A records (default 60)
-	TTL int
+	TTL int `json:"ttl"`
 
 	// Resolver port: port used to listen for slave requests (default 53)
-	Port int
+	Port int `json:"port"`
 
 	//  Domain: name of the domain used (default "mesos", ie .mesos domain)
-	Domain string
+	Domain string `json:"domain"`
 
 	// DNS server: IP address of the DNS server for forwarded accesses
-	Resolvers []string
+	Resolvers []string `json:"resolver"`
 
 	// Timeout is the default connect/read/write timeout for outbound
 	// queries
-	Timeout int
+	Timeout int `json:"timeout"`
 
 	// File is the location of the config.json file
-	File string
+	File string `json:"file"`
 
 	// Email is the rname for a SOA
-	Email string
+	Email string `json:"email"`
 
 	// Mname is the mname for a SOA
 	Mname string
 
 	// ListenAddr is the server listener address
 	Listener string
+
+	// Verbose is the logging level
+	Verbose bool
 }
 
-// SetConfig instantiates a Config struct read in from config.json
-func SetConfig(cjson string) (c Config) {
-	c = Config{
+func Flags(prefix string) []cli.Flag {
+	evname := func(n string) string {
+		return fmt.Sprintf("%s_%s", strings.ToUpper(prefix), strings.ToUpper(n))
+	}
+	defaults := New()
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:   "V, verbose",
+			EnvVar: evname("VERBOSE"),
+		},
+		cli.StringFlag{
+			Name:   "j, jsonconfig",
+			Usage:  "json configuration file",
+			EnvVar: evname("JSONCONFIG"),
+		},
+		cli.StringFlag{
+			Name:   "m, masters",
+			Value:  "127.0.0.1:5050",
+			Usage:  "comma sperated list of mesos master servers example: 1.1.1.1:5050,2.2.2.2:5050,3.3.3.3:5050",
+			EnvVar: evname("MASTERS"),
+		},
+		cli.DurationFlag{
+			Name:   "s, refreshseconds",
+			Value:  time.Second,
+			Usage:  "The frequency at which Mesos-DNS updates DNS records ",
+			EnvVar: evname("REFRESH"),
+		},
+		cli.DurationFlag{
+			Name:   "t, ttl",
+			Value:  time.Second,
+			Usage:  "The time to live value for DNS records served by Mesos-DNS",
+			EnvVar: evname("TTL"),
+		},
+		cli.StringFlag{
+			Name:   "d, domain",
+			Value:  "mesos",
+			Usage:  "The domain name for the Mesos cluster",
+			EnvVar: evname("DOMAIN"),
+		},
+		cli.IntFlag{
+			Name:   "p, port",
+			Value:  53,
+			Usage:  "The port number that Mesos-DNS monitors for incoming DNS requests",
+			EnvVar: evname("PORT"),
+		},
+		cli.StringFlag{
+			Name:   "r, resolver",
+			Usage:  "A comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the domain.",
+			Value:  "",
+			EnvVar: evname("RESOLVER"),
+		},
+		cli.DurationFlag{
+			Name:   "T, timeout",
+			Usage:  "The timeout threshold, requests to external DNS requests.",
+			Value:  time.Second * 5,
+			EnvVar: evname("TIMEOUT"),
+		},
+		cli.StringFlag{
+			Name:   "l, listener",
+			Usage:  "The IP address of Mesos-DNS. In SOA replies.",
+			Value:  "0.0.0.0",
+			EnvVar: evname("LISTENER"),
+		},
+		cli.StringFlag{
+			Name:   "e, email",
+			Usage:  "The email address of the Mesos domain name administrator. In Soa replies.",
+			Value:  "root.mesos-dns.mesos",
+			EnvVar: evname("EMAIL"),
+		},
+	}
+}
+
+func New() Config {
+	return Config{
 		RefreshSeconds: 60,
 		TTL:            60,
 		Domain:         "mesos",
@@ -63,58 +142,107 @@ func SetConfig(cjson string) (c Config) {
 		Resolvers:      []string{"8.8.8.8"},
 		Listener:       "0.0.0.0",
 	}
+}
 
+func (conf *Config) LoadFromContext(c *cli.Context) error {
+
+	conf.Verbose = c.Bool("verbose")
+
+	if c.IsSet("masters") {
+		conf.Masters = strings.Split(c.String("masters"), ",")
+	}
+
+	if c.IsSet("refreshseconds") {
+		conf.RefreshSeconds = int(c.Duration("refreshseconds").Seconds())
+	}
+
+	if c.IsSet("ttl") {
+		conf.TTL = int(c.Duration("ttl").Seconds())
+	}
+
+	if c.IsSet("domain") {
+		conf.Domain = c.String("domain")
+	}
+
+	if c.IsSet("port") {
+		conf.Port = c.Int("port")
+	}
+
+	if c.IsSet("resolvers") {
+		conf.Resolvers = strings.Split(c.String("resolvers"), ",")
+	}
+
+	if c.IsSet("timeout") {
+		conf.Timeout = int(c.Duration("timeout").Seconds())
+	}
+
+	if c.IsSet("listener") {
+		conf.Listener = c.String("listener")
+	}
+
+	if c.IsSet("email") {
+		conf.Email = c.String("email")
+	}
+
+	return nil
+
+}
+
+func (conf *Config) LoadFromFile(cjson string) error {
 	usr, _ := user.Current()
 	dir := usr.HomeDir + "/"
 	cjson = strings.Replace(cjson, "~/", dir, 1)
 
 	path, err := filepath.Abs(cjson)
 	if err != nil {
-		logging.Error.Println("cannot find configuration file")
-		os.Exit(1)
+		logging.Error.Println("JSON File path error:", err)
+		return err
 	}
 
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		logging.Error.Println("missing configuration file")
-		os.Exit(1)
+		logging.Error.Println("JSON file error:", err)
+		return err
 	}
 
-	err = json.Unmarshal(b, &c)
+	fmt.Println(string(b))
+
+	err = json.Unmarshal(b, conf)
 	if err != nil {
-		logging.Error.Println(err)
+		logging.Error.Println("JSON Unmarshal Error:", err)
+		return err
 	}
 
-	if len(c.Resolvers) == 0 {
-		c.Resolvers = GetLocalDNS()
+	return nil
+}
+
+func (conf *Config) Check() error {
+
+	if len(conf.Masters) == 0 {
+		logging.Error.Println("please specify mesos masters in config.json, environment, or args")
+		return errors.New("masters no in file, environment or args")
 	}
 
-	if len(c.Masters) == 0 {
-		logging.Error.Println("please specify mesos masters in config.json")
-		os.Exit(1)
+	if conf.Port < 0 || conf.Port > 65535 {
+		logging.Error.Println("Port must be between 0-65535")
+		return errors.New("Port must be between 0-65535")
 	}
 
-	c.Email = strings.Replace(c.Email, "@", ".", -1)
-	if c.Email[len(c.Email)-1:] != "." {
-		c.Email = c.Email + "."
+	if len(conf.Resolvers) == 0 {
+		conf.Resolvers = GetLocalDNS()
 	}
 
-	c.Domain = strings.ToLower(c.Domain)
-	c.Mname = "mesos-dns." + c.Domain + "."
+	conf.Email = strings.Replace(conf.Email, "@", ".", -1)
+	if conf.Email[len(conf.Email)-1:] != "." {
+		conf.Email = conf.Email + "."
+	}
 
-	logging.Verbose.Println("Mesos-DNS configuration:")
-	logging.Verbose.Println("   - Masters: " + strings.Join(c.Masters, ", "))
-	logging.Verbose.Println("   - RefreshSeconds: ", c.RefreshSeconds)
-	logging.Verbose.Println("   - TTL: ", c.TTL)
-	logging.Verbose.Println("   - Domain: " + c.Domain)
-	logging.Verbose.Println("   - Port: ", c.Port)
-	logging.Verbose.Println("   - Timeout: ", c.Timeout)
-	logging.Verbose.Println("   - Listener: " + c.Listener)
-	logging.Verbose.Println("   - Resolvers: " + strings.Join(c.Resolvers, ", "))
-	logging.Verbose.Println("   - Email: " + c.Email)
-	logging.Verbose.Println("   - Mname: " + c.Mname)
+	conf.Domain = strings.ToLower(conf.Domain)
 
-	return c
+	conf.Mname = "mesos-dns." + conf.Domain + "."
+
+	return nil
+
 }
 
 // localAddies returns an array of local ipv4 addresses

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func init() {
-	logging.VerboseFlag = false
-	logging.SetupLogs()
+	logging.VerboseEnable()
 }
 
 func TestHostBySlaveId(t *testing.T) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func init() {
-	logging.VerboseFlag = false
-	logging.SetupLogs()
+	logging.VerboseEnable()
 }
 
 // dig @127.0.0.1 -p 8053 "bob.*.mesos" ANY


### PR DESCRIPTION
This adds support cli args and environment variables. 

Should be easy and discoverable how to work with the features.  I did not attempt to keep backwards compatibility of any of the current cli flags as I figured this was better (I could be wrong).  I also merged (baddly but works) the VeryVerbose stuff.  This is not good to look at, but I will correct that with a pull request to do better logging.  Something that supports levels like debug, info, etc....

Some work will still need to be done as I need to clean up the wording, but I want to put this PR sooner rather then later.  (Suggestions always welcome).  



```
NAME:
   mesos-dns - DNS-based service discovery for Mesos

USAGE:
   mesos-dns [global options] command [command options] [arguments...]

VERSION:
   0.1

AUTHOR:
  Author - <unknown@email>

COMMANDS:
   help, h      Shows a list of commands or help for one command

GLOBAL OPTIONS:
   -V, --verbose                         [$MESOS_DNS_VERBOSE]
   --VV, --veryverbose                   [$MESOS_DNS_VERYVERBOSE]
   -j, --jsonconfig                     json configuration file [$MESOS_DNS_JSONCONFIG]
   -m, --masters "127.0.0.1:5050"       comma sperated list of mesos master servers example: 1.1.1.1:5050,2.2.2.2:5050,3.3.3.3:5050 [$MESOS_DNS_MASTERS]
   -s, --refreshseconds "1s"            The frequency at which Mesos-DNS updates DNS records  [$MESOS_DNS_REFRESH]
   -t, --ttl "1s"                       The time to live value for DNS records served by Mesos-DNS [$MESOS_DNS_TTL]
   -d, --domain "mesos"                 The domain name for the Mesos cluster [$MESOS_DNS_DOMAIN]
   -p, --port "53"                      The port number that Mesos-DNS monitors for incoming DNS requests [$MESOS_DNS_PORT]
   -r, --resolver                       A comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the domain. [$MESOS_DNS_RESOLVER]
   -T, --timeout "5s"                   The timeout threshold, requests to external DNS requests. [$MESOS_DNS_TIMEOUT]
   -l, --listener "0.0.0.0"             The IP address of Mesos-DNS. In SOA replies. [$MESOS_DNS_LISTENER]
   -e, --email "root.mesos-dns.mesos"   The email address of the Mesos domain name administrator. In Soa replies. [$MESOS_DNS_EMAIL]
   --help, -h                           show help
   --version, -v                        print the version

```

Started as #97