### PR TITLE
ZKdetect interface cleanup; address concurrency issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 default: all
 
-all: test  build
+all: test build
 
 restoredeps:
 	@echo "--> Restoring build dependencies"

--- a/records/generator.go
+++ b/records/generator.go
@@ -159,12 +159,12 @@ func yankPorts(ports string) []string {
 
 // findMaster tries each master and looks for the leader
 // if no leader responds it errors
-func (rg *RecordGenerator) findMaster(c Config) (StateJSON, error) {
+func (rg *RecordGenerator) findMaster(c *Config) (StateJSON, error) {
 	var sj StateJSON
 
-	if c.leader != "" {
-		logging.VeryVerbose.Println("Zookeeper says the leader is: ", c.leader)
-		ip, port, err := getProto(c.leader)
+	if leader := c.getLeader(); leader != "" {
+		logging.VeryVerbose.Println("Zookeeper says the leader is: ", leader)
+		ip, port, err := getProto(leader)
 		if err != nil {
 			logging.Error.Println(err)
 		}
@@ -224,7 +224,7 @@ func getProto(pair string) (string, string, error) {
 //  _<tag>.<service>.<framework>._<protocol>..mesos
 // it also tries different mesos masters if one is not up
 // this will shudown if it can't connect to a mesos master
-func (rg *RecordGenerator) ParseState(config Config) error {
+func (rg *RecordGenerator) ParseState(config *Config) error {
 
 	// try each listed mesos master before dying
 	sj, err := rg.findMaster(config)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -47,7 +47,7 @@ func (res *Resolver) resolveOut(r *dns.Msg, nameserver string, proto string, cnt
 	if (in != nil) && (len(in.Answer) == 0) && (!in.MsgHdr.Authoritative) && (len(in.Ns) > 0) && (err != nil) {
 
 		if cnt == recurseCnt {
-			logging.CurLog.NonMesosRecursed += 1
+			logging.CurLog.NonMesosRecursed.Inc()
 		}
 
 		if cnt > 0 {
@@ -196,18 +196,18 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// tracing info
-	logging.CurLog.NonMesosRequests += 1
+	logging.CurLog.NonMesosRequests.Inc()
 
 	if err != nil {
 		logging.Error.Println(err)
-		logging.CurLog.NonMesosFailed += 1
+		logging.CurLog.NonMesosFailed.Inc()
 	} else {
 
 		// nxdomain
 		if len(m.Answer) == 0 {
-			logging.CurLog.NonMesosNXDomain += 1
+			logging.CurLog.NonMesosNXDomain.Inc()
 		} else {
-			logging.CurLog.NonMesosSuccess += 1
+			logging.CurLog.NonMesosSuccess.Inc()
 		}
 	}
 
@@ -289,10 +289,10 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 	m.Answer = shuffleAnswers(m.Answer)
 
 	// tracing info
-	logging.CurLog.MesosRequests += 1
+	logging.CurLog.MesosRequests.Inc()
 
 	if err != nil {
-		logging.CurLog.MesosFailed += 1
+		logging.CurLog.MesosFailed.Inc()
 	} else if (qType == dns.TypeAAAA) && (len(res.rs.SRVs[dom]) > 0 || len(res.rs.As[dom]) > 0) {
 
 		m = new(dns.Msg)
@@ -319,11 +319,11 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 				m.Ns = append(m.Ns, rr)
 			}
 
-			logging.CurLog.MesosNXDomain += 1
+			logging.CurLog.MesosNXDomain.Inc()
 			logging.VeryVerbose.Println("total A rrs:\t" + strconv.Itoa(len(res.rs.As)))
 			logging.VeryVerbose.Println("failed looking for " + r.Question[0].String())
 		} else {
-			logging.CurLog.MesosSuccess += 1
+			logging.CurLog.MesosSuccess.Inc()
 		}
 	}
 
@@ -368,7 +368,7 @@ type Resolver struct {
 // Reload triggers a new refresh from mesos master
 func (res *Resolver) Reload() {
 	t := records.RecordGenerator{}
-	err := t.ParseState(res.Config)
+	err := t.ParseState(&res.Config)
 
 	if err == nil {
 		res.rs = t

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -255,7 +255,7 @@ func TestNonMesosHandler(t *testing.T) {
 	go res.Serve("tcp")
 
 	// wait for startup ? lame
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	// test A records
 	msg, err = fakeQuery("google.com", dns.TypeA, "udp")
@@ -264,7 +264,7 @@ func TestNonMesosHandler(t *testing.T) {
 	}
 
 	if len(msg) < 2 {
-		t.Error("not serving up A records")
+		t.Errorf("not serving up A records, expected 2 records instead of %d", len(msg))
 	}
 
 }


### PR DESCRIPTION
Fixed some problems that cropped up in `make testrace` with `GOMAXPROCS=24`. Haven't done much run-time testing of these changes.