### PR TITLE
WIP: Plugin support for mesos-dns

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/plugins"
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/resolver"
 
@@ -34,14 +35,14 @@ func main() {
 	logging.SetupLogs()
 
 	resolver.Config = records.SetConfig(*cjson)
-	for name := range resolver.Config.Plugins {
-		plugin, err := records.NewPlugin(name, &resolver.Config)
+	for name, config := range resolver.Config.Plugins {
+		plugin, err := plugins.New(name, config)
 		if err != nil {
 			logging.Error.Printf("failed to create plugin: %v", err)
 			continue
 		}
 		logging.Verbose.Printf("starting plugin %q", name)
-		plugin.Start()
+		plugin.Start(&resolver)
 		wg.Add(1)
 		go func() {
 			select {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func (c *context) AddFilter(f plugins.Filter) {
 		panic("cannot AddFilter after initialization has completed")
 	}
 	if f != nil {
+		//TODO(jdef) wrap plugin filters to handle plugin panic()s?
 		c.filters = append(c.filters, f)
 	}
 }
@@ -117,6 +118,7 @@ func (c *context) initialize() {
 
 func (c *pluginContext) HandleHttp(pattern string, handler http.Handler) {
 	//TODO(jdef) probably need to sanitize plugin names for URL compat
+	//TODO(jdef) could also handle plugin panic()s here by wrapping the handler
 	c.context.HandleHttp(fmt.Sprintf("/plugins/%s/%s", c.pluginName, pattern), handler)
 }
 

--- a/plugins/filters.go
+++ b/plugins/filters.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"github.com/miekg/dns"
+)
+
+// Registers a filter that will be invoked prior to the DNS server handling
+// the request. A filter may decide to handle the request on behalf of the
+// DNS server, in which case the chain is never invoked. To continue processing
+// the request a filter should invoke the chain. The chain will never be nil.
+type Filter interface {
+	ServeDNS(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler)
+}
+
+// Func adapter for the Filter interface.
+type FilterFunc func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler)
+
+func (f FilterFunc) ServeDNS(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+	f(w, r, chain)
+}
+
+type FilterSet []Filter
+
+// Apply this filter set to the given handler func. Filter implementations are not
+// obligated to invoke the chain, so the handler may never actually be called. This
+// particular implementation iterates through the filter set in a LIFO manner.
+func (fs FilterSet) Handler(handler dns.Handler) dns.Handler {
+	index := len(fs)
+	var chain dns.HandlerFunc
+	chain = dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		if index > 0 {
+			index--
+			fs[index].ServeDNS(w, r, chain)
+		} else {
+			handler.ServeDNS(w, r)
+		}
+	})
+	return chain
+}

--- a/plugins/filters_test.go
+++ b/plugins/filters_test.go
@@ -1,0 +1,162 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestFilters_Empty(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+	filtered := FilterSet(nil).Handler(h)
+	filtered.ServeDNS(nil, nil)
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_Single(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := false
+	filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+		filtered = true
+		if invoked {
+			t.Fatalf("end of chain already invoked")
+		}
+		// continue processing filters
+		chain.ServeDNS(w, r)
+	}))
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered {
+		t.Fatalf("filter not invoked")
+	}
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_SingleAbortive(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := false
+	filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+		filtered = true
+		if invoked {
+			t.Fatalf("end of chain already invoked")
+		}
+		// don't invoke chain, abort processing
+	}))
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered {
+		t.Fatalf("filter not invoked")
+	}
+	if invoked {
+		t.Fatalf("end of filter chain invoked")
+	}
+}
+
+func TestFilters_Multi(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := []bool{false, false, false}
+	for k, _ := range filtered {
+		i := k // don't use a loop var in a callback func
+		filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+			filtered[i] = true
+			if invoked {
+				t.Fatalf("end of chain already invoked")
+			}
+
+			// test LIFO algorithm: "lower" filters should not have been invoked
+			for j := 0; j < i; j++ {
+				if filtered[j] {
+					t.Fatalf("filter invoked out of order")
+				}
+			}
+
+			// continue processing filters
+			chain.ServeDNS(w, r)
+		}))
+	}
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	for i, f := range filtered {
+		if !f {
+			t.Fatalf("filter %d not invoked", i)
+		}
+	}
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_MultiAbortive(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := []bool{false, false, false}
+	for k, _ := range filtered {
+		i := k // don't use a loop var in a callback func
+		filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+			filtered[i] = true
+			if invoked {
+				t.Fatalf("end of chain already invoked")
+			}
+
+			// test LIFO algorithm: "lower" filters should not have been invoked
+			for j := 0; j < i; j++ {
+				if filtered[j] {
+					t.Fatalf("filter invoked out of order")
+				}
+			}
+
+			// abort when i == 1
+			if i != 1 {
+				chain.ServeDNS(w, r)
+			}
+		}))
+	}
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered[2] {
+		t.Fatalf("filter 2 not invoked")
+	}
+	if !filtered[1] {
+		t.Fatalf("filter 1 not invoked")
+	}
+	if filtered[0] {
+		t.Fatalf("filter 0 invoked")
+	}
+	if invoked {
+		t.Fatalf("end of filter chain invoked")
+	}
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -8,24 +8,43 @@ import (
 	"github.com/mesosphere/mesos-dns/resolver"
 )
 
-// a plugin has a single use lifecycle: once started, it may be stopped. once stopped,
+// A plugin has a single use lifecycle: once started, it may be stopped. once stopped,
 // it may not be restarted.
 type Plugin interface {
-	// starts any requisite background tasks for the plugin, should return immediately
-	Start(*resolver.Resolver)
-	// stops any running background tasks for the plugin, should return immediately
-	Stop(*resolver.Resolver)
-	// returns a signal chan that's closed once the plugin has terminated
+	// Performs initialization and starts any requisite background tasks for the plugin.
+	// Pre-server-startup actions such as Filter or resolver.Reloader registration must
+	// be completed before this func returns. This func is not expected to block for long
+	// and should return relatively quickly.
+	Start(Context)
+	// Stops any running background tasks for the plugin, should return immediately.
+	Stop()
+	// Returns a signal chan that's closed once the plugin has terminated.
 	Done() <-chan struct{}
 }
 
+// Build a new instance of a Plugin given some JSON configuration data.
 type Factory func(json.RawMessage) (Plugin, error)
+
+type Context interface {
+	// Return a pointer to the mesos-dns Resolver.
+	Resolver() *resolver.Resolver
+
+	// Adds a new filter handle some kind of pre- or post-processing of
+	// DNS requests and/or responses.
+	AddFilter(Filter)
+
+	// Return a signal chan that closes when the server enters shutdown mode.
+	Done() <-chan struct{}
+}
 
 var (
 	pluginsLock sync.Mutex
 	plugins     = map[string]Factory{}
 )
 
+// Register a new Factory implementation for the given plugin name. Both fields
+// are required and name is not allowed to be empty. It's recommended that names
+// use a domain/label convention, for example "mesos-dns.io/fancyPlugin".
 func Register(name string, f Factory) error {
 	if name == "" {
 		return fmt.Errorf("illegal plugin name")
@@ -45,6 +64,9 @@ func Register(name string, f Factory) error {
 	return nil
 }
 
+// Create a new plugin for the registered name and the given JSON configuration.
+// Will return an error if either the name is unregistered or else if the registered
+// factory generates an error attempting to build a new plugin instance.
 func New(name string, raw json.RawMessage) (Plugin, error) {
 	factory, found := func() (f Factory, ok bool) {
 		pluginsLock.Lock()

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/mesosphere/mesos-dns/resolver"
@@ -32,6 +33,9 @@ type Context interface {
 	// Adds a new filter handle some kind of pre- or post-processing of
 	// DNS requests and/or responses.
 	AddFilter(Filter)
+
+	// Handle registers the HTTP handler for the given pattern. If a handler already exists for pattern, Handle panics.
+	HandleHttp(pattern string, handler http.Handler)
 
 	// Return a signal chan that closes when the server enters shutdown mode.
 	Done() <-chan struct{}

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -58,9 +58,18 @@ func TestPluginConfig(t *testing.T) {
 			},
 		}, nil
 	}))
-	json := `{"plugins":{"fake":{"Foo":123}}}`
-	conf := records.ParseConfig([]byte(json), records.Config{Masters: []string{"bar"}, Email: "a@b.c"})
-	raw, found := conf.Plugins["fake"]
+	jsonData := `{"plugins":[{"name":"fake","settings":{"Foo":123}}]}`
+	conf := records.ParseConfig([]byte(jsonData), records.Config{Masters: []string{"bar"}, Email: "a@b.c"})
+
+	var raw json.RawMessage
+	found := false
+	for _, pconfig := range conf.Plugins {
+		if pconfig.Name == "fake" {
+			found = true
+			raw = pconfig.Settings
+			break
+		}
+	}
 	if !found {
 		t.Fatalf("failed to locate fake plugin configuration")
 	}

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records"
-	"github.com/mesosphere/mesos-dns/resolver"
 )
 
 type FakePluginConfig struct {
@@ -17,23 +16,23 @@ type FakePluginConfig struct {
 
 type fakePlugin struct {
 	FakePluginConfig
-	startFunc func(*resolver.Resolver)
-	stopFunc  func(*resolver.Resolver)
+	startFunc func(Context)
+	stopFunc  func()
 	done      chan struct{}
 	doneOnce  sync.Once
 }
 
-func (p *fakePlugin) Start(r *resolver.Resolver) {
+func (p *fakePlugin) Start(ctx Context) {
 	if p.startFunc != nil {
-		p.startFunc(r)
+		p.startFunc(ctx)
 	}
 }
 
-func (p *fakePlugin) Stop(r *resolver.Resolver) {
+func (p *fakePlugin) Stop() {
 	p.doneOnce.Do(func() {
 		close(p.done)
 		if p.stopFunc != nil {
-			p.stopFunc(r)
+			p.stopFunc()
 		}
 	})
 }
@@ -54,7 +53,7 @@ func TestPluginConfig(t *testing.T) {
 		return &fakePlugin{
 			FakePluginConfig: c,
 			done:             make(chan struct{}),
-			startFunc: func(r *resolver.Resolver) {
+			startFunc: func(ctx Context) {
 				foo = c.Foo
 			},
 		}, nil

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -1,0 +1,78 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/resolver"
+)
+
+type FakePluginConfig struct {
+	Foo int `json:"foo,omitempty"`
+}
+
+type fakePlugin struct {
+	FakePluginConfig
+	startFunc func(*resolver.Resolver)
+	stopFunc  func(*resolver.Resolver)
+	done      chan struct{}
+	doneOnce  sync.Once
+}
+
+func (p *fakePlugin) Start(r *resolver.Resolver) {
+	if p.startFunc != nil {
+		p.startFunc(r)
+	}
+}
+
+func (p *fakePlugin) Stop(r *resolver.Resolver) {
+	p.doneOnce.Do(func() {
+		close(p.done)
+		if p.stopFunc != nil {
+			p.stopFunc(r)
+		}
+	})
+}
+
+func (p *fakePlugin) Done() <-chan struct{} {
+	return p.done
+}
+
+func TestPluginConfig(t *testing.T) {
+	logging.SetupLogs()
+
+	foo := 0
+	Register("fake", Factory(func(raw json.RawMessage) (Plugin, error) {
+		var c FakePluginConfig
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal FakePluginConfig: %v", err)
+		}
+		return &fakePlugin{
+			FakePluginConfig: c,
+			done:             make(chan struct{}),
+			startFunc: func(r *resolver.Resolver) {
+				foo = c.Foo
+			},
+		}, nil
+	}))
+	json := `{"plugins":{"fake":{"Foo":123}}}`
+	conf := records.ParseConfig([]byte(json), records.Config{Masters: []string{"bar"}, Email: "a@b.c"})
+	raw, found := conf.Plugins["fake"]
+	if !found {
+		t.Fatalf("failed to locate fake plugin configuration")
+	}
+
+	p, err := New("fake", raw)
+	if err != nil {
+		t.Fatalf("failed to create fake plugin instance: %v", err)
+	}
+
+	p.Start(nil)
+	if foo != 123 {
+		t.Fatalf("plugin not started successfully")
+	}
+}

--- a/records/config.go
+++ b/records/config.go
@@ -13,6 +13,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+type PluginConfig struct {
+	Name     string          `json:"name,omitempty"`
+	Settings json.RawMessage `json:"settings,omitempty"`
+}
+
 // Config holds mesos dns configuration
 type Config struct {
 
@@ -51,7 +56,7 @@ type Config struct {
 	Listener string
 
 	// allow plugins to consume their own JSON configuration
-	Plugins map[string]json.RawMessage
+	Plugins []PluginConfig
 }
 
 // SetConfig instantiates a Config struct read in from config.json

--- a/records/config.go
+++ b/records/config.go
@@ -83,7 +83,11 @@ func SetConfig(cjson string) (c Config) {
 		os.Exit(1)
 	}
 
-	err = json.Unmarshal(b, &c)
+	return ParseConfig(b, c)
+}
+
+func ParseConfig(actualjson []byte, c Config) Config {
+	err := json.Unmarshal(actualjson, &c)
 	if err != nil {
 		logging.Error.Println(err)
 	}

--- a/records/config.go
+++ b/records/config.go
@@ -49,6 +49,9 @@ type Config struct {
 
 	// ListenAddr is the server listener address
 	Listener string
+
+	// allow plugins to consume their own JSON configuration
+	Plugins map[string]json.RawMessage
 }
 
 // SetConfig instantiates a Config struct read in from config.json

--- a/records/plugins.go
+++ b/records/plugins.go
@@ -1,0 +1,61 @@
+package records
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// a plugin has a single use lifecycle: once started, it may be stopped. once stopped,
+// it may not be restarted.
+type Plugin interface {
+	// starts any requisite background tasks for the plugin, should return immediately
+	Start()
+	// stops any running background tasks for the plugin, should return immediately
+	Stop()
+	// returns a signal chan that's closed once the plugin has terminated
+	Done() <-chan struct{}
+}
+
+type PluginFactory func(json.RawMessage) (Plugin, error)
+
+var (
+	pluginsLock sync.Mutex
+	plugins     = map[string]PluginFactory{}
+)
+
+func RegisterPlugin(name string, f PluginFactory) error {
+	if name == "" {
+		return fmt.Errorf("illegal plugin name")
+	}
+	if f == nil {
+		return fmt.Errorf("nil PluginFactory not allowed")
+	}
+
+	pluginsLock.Lock()
+	defer pluginsLock.Unlock()
+
+	if _, found := plugins[name]; found {
+		return fmt.Errorf("PluginFactory for %q is already registered", name)
+	}
+
+	plugins[name] = f
+	return nil
+}
+
+func NewPlugin(name string, c *Config) (Plugin, error) {
+	raw, found := c.Plugins[name]
+	if !found {
+		return nil, fmt.Errorf("no configuration found for plugin name %q", name)
+	}
+	factory, found := func() (f PluginFactory, ok bool) {
+		pluginsLock.Lock()
+		defer pluginsLock.Unlock()
+		f, ok = plugins[name]
+		return
+	}()
+	if !found {
+		return nil, fmt.Errorf("no PluginFactory registered for plugin name %q", name)
+	}
+	return factory(raw)
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -102,7 +102,7 @@ func fakeDNS(port int) (Resolver, error) {
 	}
 
 	masters := []string{"144.76.157.37:5050"}
-	res.rs = records.RecordGenerator{}
+	res.rs = &records.RecordGenerator{}
 	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters)
 
 	return res, nil


### PR DESCRIPTION
Looking for some feedback here. Ultimately I'd like to write up a kubernetes-mesos plugin that exposes kubernetes services to mesos-dns, but I need some scaffolding in place first.

TODOs:
- [x] add optional HTTP handler/filter registration for plugins
- [ ] support custom flag sets for plugins, rely less on config.json file for settings

Some plugin ideas:
- examine registration records and push updates to an external DNS service (e.g. Route53)
- "generic" HTTP endpoint that accepts POSTs, allows external processes to add/remove records
  - ~~POST `/services/{service-name}?ip={ip-address}&port={port}&ttl={ttl}&priority={priority}&weight={weight}`~~
  - records would be added to `services.mesos` namespace
- emulate a SkyDNS/etcd endpoint for PUT's and DELETE's
    - `/skydns/{reverse}/{domain}/{name}`, for example:
    - `/skydns/mesos/kubernetes/services/{k8s-namespace}/{k8s-service}`
    - PUT accepts JSON [blobs][2]
    - goal: compatibility with properly configured [kube2sky][1]
- support PUSH-based updates: custom HTTP plugins that accept JSON posts, specific to frameworks
  - POST `/plugins/marathon/services/{...}`
    - plugin adds records to `services.marathon.mesos` namespace
    - secondary, out of band process, could process Marathon `/events` stream and periodically POST to this endpoint
    - alternatively, plugin could expose an endpoint for receiving a Marathon `/events` stream

[1]: https://github.com/GoogleCloudPlatform/kubernetes/blob/release-0.13/cluster/addons/dns/kube2sky/kube2sky.go
[2]: https://github.com/skynetservices/skydns/blob/master/msg/service.go