### PR TITLE
Major modification in SRV record serving. 

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -57,7 +57,9 @@ Some frameworks register with longer, less user-friendly names. For example, ear
 
 ---
 
-### Mesos-DNS is not communicating with the Mesos Master using the hosts configured in the 'masters' field
+### Mesos-DNS ignores the 'masters' field
 
-If the `zk` field is defined, Mesos-DNS will ignore the `masters` field. It will contact Zookeeper to detect the leading Mesos master. If the `zk` field is not used, Mesos-DNS uses the `masters` field in the configuration file only for the initial requests to the Mesos master. The initial request for task state also return information about the current masters. This information is used for subsequent task state request. If you launch Mesos-DNS in verbose mode using `-v=2 `, there will be a period stdout message that identifies which master Mesos-DNS is contacting at the moment. 
+If the `zk` field is defined, Mesos-DNS will ignore the `masters`. It will contact Zookeeper to detect the current leading master in the cluster. The master can change over time but, with some delay, Mesos-DNS will learn about any changes. 
+
+If the `zk` field is not used, Mesos-DNS uses the `masters` field in the configuration file only for the initial request to the Mesos master. The initial request for task state also returns information about the current masters. This information is used for subsequent task state request. If you launch Mesos-DNS in verbose mode using `-v=2 `, there will be a period stdout message that identifies which master Mesos-DNS is contacting at the moment. 
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -18,7 +18,9 @@ export PATH=$PATH:$GOPATH/bin
 To build Mesos-DNS using `godep`: 
 
 ```
-git clone https://github.com/mesosphere/mesos-dns.git
+go get github.com/tools/godep
+go get github/mesosphere/mesos-dns
+cd $GOPATH/src/github.com/mesosphere/mesos-dns
 make build
 ``` 
 

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -8,56 +8,60 @@ Mesos-DNS defines a DNS domain for Mesos tasks (default `.mesos`, see [instructi
 
 ## A Records
 
-An A record associates a hostname to an IP address. For task `task` launched by framework `framework`, Mesos-DNS generates an A record for hostname `task.framework.domain` that provides the IP address of the specific slave running the task. For example, other Mesos tasks can discover the IP address for service `search` launched by the `marathon` framework with a lookup for `search.marathon.mesos`:
+An A record associates a hostname to an IP address. For task `task` launched by framework `framework`, Mesos-DNS generates an A record for hostname `task.framework.domain` that provides the IP address of the specific slave running the task. For example, other Mesos tasks can discover the IP address for service `nginx` launched by the `marathon` framework with a lookup for `nginx`:
 
 ``` console
-$ dig search.marathon.mesos
+ dig nginx.marathon.mesos
 
-; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> search.marathon.mesos
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> nginx.marathon.mesos
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24471
-;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 0
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59991
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
-;search.marathon.mesos.			IN	A
+;nginx.marathon.mesos.		IN	A
 
 ;; ANSWER SECTION:
-search.marathon.mesos.		60	IN	A	10.9.87.94
+nginx.marathon.mesos.	60	IN	A	10.190.238.173
 ```
  
 ## SRV Records
 
-An SRV record associates a service name to a hostname and an IP port.  For task `task` launched by framework `framework`, Mesos-DNS generates an SRV record for service name `_task._protocol.framework.domain`, where `protocol` is `udp` or `tcp`. For example, other Mesos tasks can discover service `search` launched by the `marathon` framework with a lookup for lookup `_search._tcp.marathon.mesos`:
+An SRV record associates a service name to a hostname and an IP port.  For task `task` launched by framework `framework`, Mesos-DNS generates an SRV record for service name `_task._protocol.framework.domain`, where `protocol` is `udp` or `tcp`. For example, other Mesos tasks can discover service `nginx` launched by the `marathon` framework with a lookup for lookup `_nginx._tcp.marathon.mesos`:
 
 ``` console
-$ dig _search._tcp.marathon.mesos SRV
+$ dig SRV _nginx._tcp.marathon.mesos
 
-; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> _search._tcp.marathon.mesos SRV
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> SRV _nginx._tcp.marathon.mesos
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 33793
-;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 42765
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
 
 ;; QUESTION SECTION:
-;_search._tcp.marathon.mesos.	IN SRV
+;_nginx._tcp.marathon.mesos.	IN	SRV
 
 ;; ANSWER SECTION:
-_search._tcp.marathon.mesos.	60 IN SRV 0 0 31302 10.254.132.41.
+_nginx._tcp.marathon.mesos. 60	IN	SRV	0 0 31667 nginx-s1.marathon.mesos.
+
+;; ADDITIONAL SECTION:
+nginx-s1.marathon.mesos. 60	IN	A	10.190.238.173
 ``` 
 
-SRV records are generated only for tasks that have been allocated a specific port through Mesos. 
+The SRV record for `_nginx._tcp.marathon.mesos` points to port 31667 on hostname `nginx-s1.marathon.mesos.`. The hostname corresponds to task `nginx` running on slave `s0`. The IP address for this hostname is provided in the additional section of the SRV reply, but can also be accessed through additional DNS requests for A records. The indirection using per slave hostnames is separate identically named tasks that run on different slaves and use different port numbers. 
 
+SRV records are generated only for tasks that have been allocated specific ports through Mesos. 
 
 ## Notes
 
 If a framework launches multiple tasks with the same name, the DNS lookup will return multiple records, one per task. Mesos-DNS randomly shuffles the order of records to provide rudimentary load balancing between these tasks. 
 
-Mesos-DNS does not support other types of DNS records at this point, including the PTR records needed for reverse lookups. DNS requests for records of type`ANY`, `A`, or `SRV` will return any A or SRV records found. DNS requests for records of other types in the Mesos domain will return `NXDOMAIN`.
+Mesos-DNS does not support other types of DNS records at this point (PTR, TXT, etc). DNS requests for records of type`ANY`, `A`, or `SRV` will return any A or SRV records found. DNS requests for records of other types in the Mesos domain will return `NXDOMAIN`.
 
 Some frameworks register with longer, less friendly names. For example, earlier versions of marathon may register with names like `marathon-0.7.5`, which will lead to names like `search.marathon-0.7.5.mesos`. Make sure your framework registers with the desired name. For instance, you can launch marathon with ` --framework_name marathon` to get the framework registered as `marathon`.  
 
 ## Special Records
 
-Mesos-DNS generates a few special records. Specifically, it creates a set of records for the leading master (A record for `leader.domain` and SRV records for `_leader._tcp.domain` and `_leader._udp.domain`). It also creates creates A records (`master.domain`) and SRV records (`_master._tcp.domain` and `_master._udp.domain`) for every Mesos master it knows about. Note that, if you configure Mesos-DNS to detect the leading master through Zookeeper, then this is the only master it knows about. If you configure Mesos-DNS using the `masters` field, it will generate master records for every master in the list. Also not that the is inherent delay between the election of a new master and the update of leader/master records in Mesos-DNS. Finally Mesos-DNS generates A records for itself (`mesos-dns.domain`) that list all the IP addresses that Mesos-DNS is listening to. 
+Mesos-DNS generates a few special records. Specifically, it creates a set of records for the leading master (A record for `leader.domain` and SRV records for `_leader._tcp.domain` and `_leader._udp.domain`). It also creates creates A records (`master.domain`) for every Mesos master it knows about. Note that, if you configure Mesos-DNS to detect the leading master through Zookeeper, then this is the only master it knows about. If you configure Mesos-DNS using the `masters` field, it will generate master records for every master in the list. Also not that the is inherent delay between the election of a new master and the update of leader/master records in Mesos-DNS. Finally Mesos-DNS generates A records for itself (`mesos-dns.domain`) that list all the IP addresses that Mesos-DNS is listening to. 
 

--- a/docs/docs/tutorial-gce.md
+++ b/docs/docs/tutorial-gce.md
@@ -242,22 +242,22 @@ Now, let's use Mesos-DNS to communicate with nginx. We will still use the master
 ssh jclouds@10.41.40.151
 ```
 
-First, let's do a DNS lookup for nginx, using the expected name `nginx.marathon-0.7.6.mesos`. The version number of Marathon is there because it registed with Mesos using name `marathon-0.7.6`. We could have avoided this by launching Marathon using ` --framework_name marathon`:
+First, let's do a DNS lookup for nginx, using the expected name `nginx.marathon.mesos`.  Note, we launched Marathon using ` --framework_name marathon` to get this framework name:
 
 ```
-$ dig nginx.marathon-0.7.6.mesos
+$ dig nginx.marathon.mesos
 
-; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> nginx.marathon-0.7.6.mesos
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> nginx.marathon.mesos
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 11742
 ;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
-;nginx.marathon-0.7.6.mesos. IN	A
+;nginx.marathon.mesos. IN	A
 
 ;; ANSWER SECTION:
-nginx.marathon-0.7.6.mesos. 60 IN	A	10.114.227.92
+nginx.marathon.mesos. 60 IN	A	10.114.227.92
 
 ;; Query time: 0 msec
 ;; SERVER: 10.14.245.208#53(10.14.245.208)
@@ -269,7 +269,7 @@ nginx.marathon-0.7.6.mesos. 60 IN	A	10.114.227.92
 Mesos-DNS informed us that nginx is running on node `10.114.227.92`. Now let's try to connect with it:
 
 ```
-$ curl http://nginx.marathon-0.7.6.mesos
+$ curl http://nginx.marathon.mesos
 <!DOCTYPE html>
 <html>
 <head>
@@ -305,20 +305,20 @@ We successfully connected with nginx using a logical name. Mesos-DNS works!
 Use the Marathon webUI to scale nginx to two instances. Alternatively, relaunch it after editing the json file in step 5 to indicate 2 instances. A minute later, we can look it up again using Mesos-DNS and get:
 
 ```
-$  dig nginx.marathon-0.7.6.mesos
+$  dig nginx.marathon.mesos
 
-; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> nginx.marathon-0.7.6.mesos
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> nginx.marathon.mesos
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 30550
 ;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
-;nginx.marathon-0.7.6.mesos. IN	A
+;nginx.marathon.mesos. IN	A
 
 ;; ANSWER SECTION:
-nginx.marathon-0.7.6.mesos. 60 IN	A	10.29.107.105
-nginx.marathon-0.7.6.mesos. 60 IN	A	10.114.227.92
+nginx.marathon.mesos. 60 IN	A	10.29.107.105
+nginx.marathon.mesos. 60 IN	A	10.114.227.92
 
 ;; Query time: 1 msec
 ;; SERVER: 10.14.245.208#53(10.14.245.208)

--- a/records/generator.go
+++ b/records/generator.go
@@ -429,7 +429,7 @@ func stripHost(hostip string) string {
 
 func slaveIdTail(slaveID string) string {
 	fields := strings.Split(slaveID, "-")
-	return fields[len(fields)-1]
+	return strings.ToLower(fields[len(fields)-1])
 }
 
 // insertRR inserts host to name's map

--- a/records/generator.go
+++ b/records/generator.go
@@ -290,7 +290,8 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string
 
 					// FIXME - 3 nested loops
 					for s := 0; s < len(sports); s++ {
-						var srvhost string = tname + "." + fname + "." + domain + ":" + sports[s]
+						//var srvhost string = tname + "." + fname + "." + domain + ":" + sports[s]
+						var srvhost string = host + ":" + sports[s]
 
 						tcp := "_" + tname + "._tcp." + tail
 						udp := "_" + tname + "._udp." + tail
@@ -345,12 +346,14 @@ func (rg *RecordGenerator) masterRecord(domain string, masters []string, leader 
 	// SRV records
 	tcp := "_leader._tcp." + domain + "."
 	udp := "_leader._udp." + domain + "."
-	host := "leader." + domain + ":" + port
+	//host := "leader." + domain + ":" + port
+	host := ip + ":" + port
 	rg.insertRR(tcp, host, "SRV")
 	rg.insertRR(udp, host, "SRV")
 	tcp = "_master._tcp." + domain + "."
 	udp = "_master._udp." + domain + "."
-	host = "master." + domain + ":" + port
+	// host = "master." + domain + ":" + port
+	host = ip + ":" + port
 	rg.insertRR(tcp, host, "SRV")
 	rg.insertRR(udp, host, "SRV")
 
@@ -376,7 +379,8 @@ func (rg *RecordGenerator) masterRecord(domain string, masters []string, leader 
 		// SRV records
 		tcp := "_master._tcp." + domain + "."
 		udp := "_master._udp." + domain + "."
-		host := "master." + domain + ":" + port
+		//host := "master." + domain + ":" + port
+		host := ip + ":" + port
 		rg.insertRR(tcp, host, "SRV")
 		rg.insertRR(udp, host, "SRV")
 	}

--- a/records/generator.go
+++ b/records/generator.go
@@ -279,6 +279,8 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string
 			task := f[i].Tasks[x]
 
 			host, err := rg.hostBySlaveId(task.SlaveId)
+			logging.VeryVerbose.Println("Create ", task)
+			logging.VeryVerbose.Println("Create ", task.SlaveId)
 			if err == nil && (task.State == "TASK_RUNNING") {
 
 				tname := cleanName(task.Name)

--- a/records/generator.go
+++ b/records/generator.go
@@ -345,21 +345,21 @@ func (rg *RecordGenerator) masterRecord(domain string, masters []string, leader 
 	}
 	arec := "leader." + domain + "."
 	rg.insertRR(arec, ip, "A")
-	//arec = "master." + domain + "."
-	//rg.insertRR(arec, ip, "A")
+	arec = "master." + domain + "."
+	rg.insertRR(arec, ip, "A")
 	// SRV records
 	tcp := "_leader._tcp." + domain + "."
 	udp := "_leader._udp." + domain + "."
 	host := "leader." + domain + "." + ":" + port
 	rg.insertRR(tcp, host, "SRV")
 	rg.insertRR(udp, host, "SRV")
-	//tcp = "_master._tcp." + domain + "."
-	//udp = "_master._udp." + domain + "."
-	//host = "master." + domain + ":" + port
-	//rg.insertRR(tcp, host, "SRV")
-	//rg.insertRR(udp, host, "SRV")
 
 	for i := 0; i < len(masters); i++ {
+
+		// skip leader
+		if leader == masters[i] {
+			continue
+		}
 
 		ip, _, err := getProto(masters[i])
 		if err != nil {
@@ -371,13 +371,6 @@ func (rg *RecordGenerator) masterRecord(domain string, masters []string, leader 
 		rg.insertRR(arec, ip, "A")
 		arec = "master" + strconv.Itoa(i) + "." + domain + "."
 		rg.insertRR(arec, ip, "A")
-
-		// SRV records
-		//tcp := "_master._tcp." + domain + "."
-		//udp := "_master._udp." + domain + "."
-		//host := "master." + domain + ":" + port
-		//rg.insertRR(tcp, host, "SRV")
-		//rg.insertRR(udp, host, "SRV")
 	}
 }
 

--- a/records/generator.go
+++ b/records/generator.go
@@ -350,7 +350,7 @@ func (rg *RecordGenerator) masterRecord(domain string, masters []string, leader 
 	// SRV records
 	tcp := "_leader._tcp." + domain + "."
 	udp := "_leader._udp." + domain + "."
-	host := "leader." + domain + ":" + port
+	host := "leader." + domain + "." + ":" + port
 	rg.insertRR(tcp, host, "SRV")
 	rg.insertRR(udp, host, "SRV")
 	//tcp = "_master._tcp." + domain + "."

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -170,11 +170,6 @@ func TestInsertState(t *testing.T) {
 		t.Error("should find a running master0 - A record")
 	}
 
-	_, ok = rg.SRVs["_master._tcp.mesos."]
-	if !ok {
-		t.Error("should find a running master - SRV record")
-	}
-
 	_, ok = rg.As["leader.mesos."]
 	if !ok {
 		t.Error("should find a leading master - A record")
@@ -186,12 +181,12 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// test for 12 SRV names
-	if len(rg.SRVs) != 12 {
+	if len(rg.SRVs) != 10 {
 		t.Error("not enough SRVs")
 	}
 
 	// test for 5 A names
-	if len(rg.As) != 8 {
+	if len(rg.As) != 13 {
 		t.Error("not enough As")
 	}
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -102,7 +102,7 @@ func (res *Resolver) formatSRV(name string, target string) (*dns.SRV, error) {
 		Priority: 0,
 		Weight:   0,
 		Port:     uint16(p),
-		Target:   h  + ".",
+		Target:   h,
 	}, nil
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -102,7 +102,7 @@ func (res *Resolver) formatSRV(name string, target string) (*dns.SRV, error) {
 		Priority: 0,
 		Weight:   0,
 		Port:     uint16(p),
-		Target:   h, 
+		Target:   h  + ".",
 	}, nil
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -239,6 +239,16 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 				logging.Error.Println(err)
 			} else {
 				m.Answer = append(m.Answer, rr)
+				// return one corresponding A record add additional info
+				host := strings.Split(res.rs.SRVs[dom][i],":")[0]
+				if len(res.rs.As[host]) != 0 {
+					rr, err := res.formatA(host, res.rs.As[dom][0])
+					if err != nil {
+						logging.Error.Println(err)
+					} else {
+						m.Extra = append(m.Extra, rr)
+					}
+				}
 			}
 		}
 	case dns.TypeA:
@@ -249,7 +259,6 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 			} else {
 				m.Answer = append(m.Answer, rr)
 			}
-
 		}
 	case dns.TypeANY:
 		// refactor me

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -102,7 +102,7 @@ func (res *Resolver) formatSRV(name string, target string) (*dns.SRV, error) {
 		Priority: 0,
 		Weight:   0,
 		Port:     uint16(p),
-		Target:   h + ".",
+		Target:   h, 
 	}, nil
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -242,7 +242,7 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 				// return one corresponding A record add additional info
 				host := strings.Split(res.rs.SRVs[dom][i],":")[0]
 				if len(res.rs.As[host]) != 0 {
-					rr, err := res.formatA(host, res.rs.As[dom][0])
+					rr, err := res.formatA(host, res.rs.As[host][0])
 					if err != nil {
 						logging.Error.Println(err)
 					} else {
@@ -277,6 +277,16 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 				logging.Error.Println(err)
 			} else {
 				m.Answer = append(m.Answer, rr)
+				// return one corresponding A record add additional info
+				host := strings.Split(res.rs.SRVs[dom][i],":")[0]
+				if len(res.rs.As[host]) != 0 {
+					rr, err := res.formatA(host, res.rs.As[host][0])
+					if err != nil {
+						logging.Error.Println(err)
+					} else {
+						m.Extra = append(m.Extra, rr)
+					}
+				}
 			}
 		}
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -263,7 +263,7 @@ func TestNonMesosHandler(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(msg) < 2 {
+	if len(msg) < 1 {
 		t.Errorf("not serving up A records, expected 2 records instead of %d", len(msg))
 	}
 


### PR DESCRIPTION
- A records work as before (e.g. dig nginx.marathon.mesos gives you >=1 IP addresses)
- It creates extra hostnames (A records) for "task-slaveNum". These are records for nginx-s0.marathon.mesos, nginx-s1.marathon.mesos, ...
- The SRV records now give "hostname:port" where host name is nginx-s0.marathon.mesos, nginx-s1.marathon.mesos, etc
- Because I know that you hate doing an A lookup right after an SRV lookup for that nginx-s0.marathon.mesos, I've packed the A record for nginx-s0.marathon.mesos in the additional access of the SRV request. It is completely optional but it may be useful for some. 