### PR TITLE
Version, exposed state, and locking suggestions

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 )
 
 func main() {
-	var resolver resolver.Resolver
 	var versionFlag bool
 
 	// parse flags
@@ -29,28 +28,29 @@ func main() {
 	logging.SetupLogs()
 
 	// initialize resolver
-	resolver.Config = records.SetConfig(*cjson)
-	resolver.Version = version
+	config := records.SetConfig(*cjson)
+	resolver := resolver.New(version, config)
 
 	// launch DNS server
-	if resolver.Config.DnsOn {
+	if config.DnsOn {
 		resolver.LaunchDNS()
 	}
 
 	// launch HTTP server
-	if resolver.Config.HttpOn {
+	if config.HttpOn {
 		go resolver.LaunchHTTP()
 	}
 
 	// launch Zookeeper listener
-	if resolver.Config.Zk != "" {
+	if config.Zk != "" {
 		resolver.LaunchZK()
 	}
 
 	// periodic loading of DNS state (pull from Master)
 	resolver.Reload()
-	ticker := time.NewTicker(time.Second * time.Duration(resolver.Config.RefreshSeconds))
+	ticker := time.NewTicker(time.Second * time.Duration(config.RefreshSeconds))
 	go func() {
+		//TODO(jdef) handle panics here?
 		for _ = range ticker.C {
 			resolver.Reload()
 			logging.PrintCurLog()

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -66,7 +66,7 @@ func TestShuffleAnswers(t *testing.T) {
 
 func fakeDNS(port int) (Resolver, error) {
 	var res Resolver
-	res.Config = records.Config{
+	res.config = records.Config{
 		Masters:   []string{"144.76.157.37:5050"},
 		TTL:       60,
 		Port:      port,
@@ -90,7 +90,7 @@ func fakeDNS(port int) (Resolver, error) {
 	}
 
 	masters := []string{"144.76.157.37:5050"}
-	res.rs = records.RecordGenerator{}
+	res.rs = &records.RecordGenerator{}
 	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters)
 
 	return res, nil
@@ -264,7 +264,7 @@ func TestHTTP(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	res.Version = "0.1.1"
+	res.version = "0.1.1"
 
 	go res.LaunchHTTP()
 	// wait for startup ? lame
@@ -298,7 +298,7 @@ func TestHTTP(t *testing.T) {
 	}
 	var got2 records.Config
 	err = json.Unmarshal(g2, &got2)
-	eq2 := reflect.DeepEqual(got2, res.Config)
+	eq2 := reflect.DeepEqual(got2, res.config)
 	if !eq2 {
 		t.Error("Http config API failure")
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var version = "0.1.2"
+const version = "0.1.2"


### PR DESCRIPTION
- make version a const
- don't expose resolver's config or version
- don't hold lock for as long when reading records, just copy the pointer and be done with it
