### PR TITLE
Panic handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ format:
 	@echo "--> Running go fmt"
 	@godep go fmt ./...
 
+vet: 
+	@echo "--> Running go vet"
+	@godep go vet ./...
+
 build: 
 	@echo "--> Building mesos-dns"
 	@godep go build -o mesos-dns

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,12 +1,13 @@
 package logging
 
 import (
-	"github.com/golang/glog"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"sync/atomic"
+
+	"github.com/golang/glog"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -60,7 +60,6 @@ func main() {
 		newLeader, zkErr = resolver.LaunchZK(zkInitialDetectionTimeout)
 	}
 
-	defer util.HandleCrash()
 	handleServerErr := func(name string, err error) {
 		if err != nil {
 			logging.Error.Fatalf("%s failed: %v", name, err)

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -280,7 +280,11 @@ func TestHTTP(t *testing.T) {
 	}
 	res.version = "0.1.1"
 
-	go res.LaunchHTTP()
+	errCh := res.LaunchHTTP()
+	go func() {
+		err := <-errCh
+		t.Fatalf("HTTP server stopped with err: %v", err)
+	}()
 	// wait for startup ? lame
 	time.Sleep(10 * time.Millisecond)
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -64,9 +64,8 @@ func TestShuffleAnswers(t *testing.T) {
 	}
 }
 
-func fakeDNS(port int) (Resolver, error) {
-	var res Resolver
-	res.config = records.Config{
+func fakeDNS(port int) (*Resolver, error) {
+	res := New("", records.Config{
 		Masters:    []string{"144.76.157.37:5050"},
 		TTL:        60,
 		Port:       port,
@@ -77,7 +76,7 @@ func fakeDNS(port int) (Resolver, error) {
 		SOAMname:   "ns1.mesos.",
 		HttpPort:   8123,
 		ExternalOn: true,
-	}
+	})
 
 	b, err := ioutil.ReadFile("../factories/fake.json")
 	if err != nil {
@@ -105,7 +104,11 @@ func fakeMsg(dom string, rrHeader uint16, proto string) (*dns.Msg, error) {
 
 	m := new(dns.Msg)
 	m.Question = make([]dns.Question, 1)
-	m.Question[0] = dns.Question{dns.Fqdn(dom), rrHeader, qc}
+	m.Question[0] = dns.Question{
+		Name:   dns.Fqdn(dom),
+		Qtype:  rrHeader,
+		Qclass: qc,
+	}
 
 	in, _, err := c.Exchange(m, "127.0.0.1:8053")
 	return in, err

--- a/tools/main.go
+++ b/tools/main.go
@@ -19,7 +19,11 @@ func query(dom string) {
 
 	m := new(dns.Msg)
 	m.Question = make([]dns.Question, 1)
-	m.Question[0] = dns.Question{dns.Fqdn(dom), qt, qc}
+	m.Question[0] = dns.Question{
+		Name:   dns.Fqdn(dom),
+		Qtype:  qt,
+		Qclass: qc,
+	}
 
 	_, _, err := c.Exchange(m, nameserver)
 	if err != nil {
@@ -38,5 +42,5 @@ func main() {
 
 	elapsed := time.Since(start)
 	log.Printf("benching took %s", elapsed)
-	log.Printf("doing %s/%s rps", cnt, elapsed)
+	log.Printf("doing %d/%v rps", cnt, elapsed)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+)
+
+// For testing, bypass HandleCrash.
+var ReallyCrash bool
+
+// PanicHandlers is a list of functions which will be invoked when a panic happens.
+var PanicHandlers = []func(interface{}){logPanic}
+
+// HandleCrash simply catches a crash and logs an error. Meant to be called via defer.
+func HandleCrash() {
+	if ReallyCrash {
+		return
+	}
+	if r := recover(); r != nil {
+		for _, fn := range PanicHandlers {
+			fn(r)
+		}
+	}
+}
+
+// logPanic logs the caller tree when a panic occurs.
+func logPanic(r interface{}) {
+	callers := ""
+	for i := 0; true; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		callers = callers + fmt.Sprintf("%v:%v\n", file, line)
+	}
+	log.Printf("Recovered from panic: %#v (%v)\n%v", r, r, callers)
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestHandleCrash(t *testing.T) {
+	count := 0
+	expect := 10
+	for i := 0; i < expect; i = i + 1 {
+		defer HandleCrash()
+		if i%2 == 0 {
+			panic("Test Panic")
+		}
+		count = count + 1
+	}
+	if count != expect {
+		t.Errorf("Expected %d iterations, found %d", expect, count)
+	}
+}
+
+func TestCustomHandleCrash(t *testing.T) {
+	old := PanicHandlers
+	defer func() { PanicHandlers = old }()
+	var result interface{}
+	PanicHandlers = []func(interface{}){
+		func(r interface{}) {
+			result = r
+		},
+	}
+	func() {
+		defer HandleCrash()
+		panic("test")
+	}()
+	if result != "test" {
+		t.Errorf("did not receive custom handler")
+	}
+}


### PR DESCRIPTION
- centralize panic handling for the resolver, move calls to `os.Exit` into main
- fix problems reported by `go vet`
- ran `go fmt`
- refactored config reload: can also be triggered now by detected mesos leadership changes