### PR TITLE
sanitized task names should make for good SRV service labels

### DIFF
--- a/records/generator.go
+++ b/records/generator.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -244,23 +243,6 @@ func (rg *RecordGenerator) ParseState(config *Config) error {
 	return nil
 }
 
-// cleanName sanitizes invalid characters
-func cleanName(tname string) string {
-	return stripInvalid(tname)
-}
-
-// stripInvalid remove any non-valid hostname characters
-func stripInvalid(tname string) string {
-	reg, err := regexp.Compile("[^\\w-.\\.]")
-	if err != nil {
-		logging.Error.Println(err)
-	}
-
-	s := reg.ReplaceAllString(tname, "")
-
-	return strings.ToLower(strings.Replace(s, "_", "", -1))
-}
-
 // InsertState transforms a StateJSON into RecordGenerator RRs
 func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string,
 	listener string, masters []string) error {
@@ -274,7 +256,7 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, mname string
 	// complete crap - refactor me
 	for i := 0; i < len(f); i++ {
 		fname := f[i].Name
-		fname = cleanName(fname)
+		fname = labels.AsDomainFrag(fname)
 
 		for x := 0; x < len(f[i].Tasks); x++ {
 			task := f[i].Tasks[x]

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -95,35 +95,6 @@ func TestLeaderIP(t *testing.T) {
 	}
 }
 
-type invalidHosts struct {
-	host     string
-	expected string
-}
-
-func TestStripInvalid(t *testing.T) {
-
-	var tests = []invalidHosts{
-		{"host.com", "host.com"},
-		{"space space.com", "spacespace.com"},
-		{"blah-dash.com", "blah-dash.com"},
-		{"not$1234.com", "not1234.com"},
-		{"(@ host . com", "host.com"},
-		{"MiXeDcase.CoM", "mixedcase.com"},
-	}
-
-	for _, pair := range tests {
-		url := stripInvalid(pair.host)
-		if url != pair.expected {
-			t.Error(
-				"For", pair.host,
-				"expected", pair.expected,
-				"got", url,
-			)
-		}
-	}
-
-}
-
 // ensure we are parsing what we think we are
 func TestInsertState(t *testing.T) {
 
@@ -150,12 +121,12 @@ func TestInsertState(t *testing.T) {
 		t.Error("should not find this not-running task - SRV record")
 	}
 
-	_, ok = rg.As["liquor-store.marathon-0.6.0.mesos."]
+	_, ok = rg.As["liquor-store.marathon-0.mesos."]
 	if !ok {
 		t.Error("should find this running task - A record")
 	}
 
-	_, ok = rg.As["poseidon.marathon-0.6.0.mesos."]
+	_, ok = rg.As["poseidon.marathon-0.mesos."]
 	if ok {
 		t.Error("should not find this not-running task - A record")
 	}
@@ -191,13 +162,13 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// ensure we translate the framework name as well
-	_, ok = rg.As["some-box.chronoswithaspaceandmixedcase-2.0.1.mesos."]
+	_, ok = rg.As["some-box.chronoswithaspaceandmixe.mesos."]
 	if !ok {
 		t.Error("should find this task w/a space in the framework name - A record")
 	}
 
 	// ensure we find this SRV
-	rrs := rg.SRVs["_liquor-store._tcp.marathon-0.6.0.mesos."]
+	rrs := rg.SRVs["_liquor-store._tcp.marathon-0.mesos."]
 
 	// ensure there are 3 RRDATA answers for this SRV name
 	if len(rrs) != 3 {
@@ -205,7 +176,7 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// ensure we don't find this as a SRV record
-	rrs = rg.SRVs["_liquor-store.marathon-0.6.0.mesos."]
+	rrs = rg.SRVs["_liquor-store.marathon-0.mesos."]
 	if len(rrs) != 0 {
 		t.Error("not a proper SRV record")
 	}

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -124,6 +124,34 @@ func TestStripInvalid(t *testing.T) {
 
 }
 
+func Test_asDNS952Label(t *testing.T) {
+	tests := map[string]string{
+		"":                                "",
+		"a":                               "a",
+		"-":                               "",
+		"a---":                            "a",
+		"---a---":                         "a",
+		"---a---b":                        "a---b",
+		"a.b.c.d.e":                       "a-b-c-d-e",
+		"a.c.d_de.":                       "a-c-d-de",
+		"abc123":                          "abc123",
+		"4abc123":                         "abc123",
+		"-abc123":                         "abc123",
+		"abc123-":                         "abc123",
+		"abc-123":                         "abc-123",
+		"abc--123":                        "abc--123",
+		"89fdgsf---gs7-fgs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg---123": "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-":      "fdgsf---gs7-fgs--d7fddg",
+	}
+	for untrusted, expected := range tests {
+		actual := asDNS952Label(untrusted)
+		if actual != expected {
+			t.Fatalf("expected %q instead of %q", expected, actual)
+		}
+	}
+}
+
 // ensure we are parsing what we think we are
 func TestInsertState(t *testing.T) {
 

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -124,34 +124,6 @@ func TestStripInvalid(t *testing.T) {
 
 }
 
-func Test_asDNS952Label(t *testing.T) {
-	tests := map[string]string{
-		"":                                "",
-		"a":                               "a",
-		"-":                               "",
-		"a---":                            "a",
-		"---a---":                         "a",
-		"---a---b":                        "a---b",
-		"a.b.c.d.e":                       "a-b-c-d-e",
-		"a.c.d_de.":                       "a-c-d-de",
-		"abc123":                          "abc123",
-		"4abc123":                         "abc123",
-		"-abc123":                         "abc123",
-		"abc123-":                         "abc123",
-		"abc-123":                         "abc-123",
-		"abc--123":                        "abc--123",
-		"89fdgsf---gs7-fgs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
-		"89fdgsf---gs7-fgs--d7fddg---123": "fdgsf---gs7-fgs--d7fddg1",
-		"89fdgsf---gs7-fgs--d7fddg-":      "fdgsf---gs7-fgs--d7fddg",
-	}
-	for untrusted, expected := range tests {
-		actual := asDNS952Label(untrusted)
-		if actual != expected {
-			t.Fatalf("expected %q instead of %q", expected, actual)
-		}
-	}
-}
-
 // ensure we are parsing what we think we are
 func TestInsertState(t *testing.T) {
 

--- a/records/labels/dns952.go
+++ b/records/labels/dns952.go
@@ -1,0 +1,72 @@
+package labels
+
+const DNS952MaxLength int = 24
+
+var dns952table []int32
+
+func init() {
+	const tolower = int32('a' - 'A')
+	dns952table = make([]int32, 256, 256)
+	for i := int32('A'); i < int32('Z'); i++ {
+		dns952table[i] = i + tolower
+	}
+	for i := int32('a'); i < int32('z'); i++ {
+		dns952table[i] = i
+	}
+	for i := int32('0'); i < int32('9'); i++ {
+		dns952table[i] = -i
+	}
+	dns952table[int32('-')] = -int32('-')
+	dns952table[int32('.')] = -int32('-')
+	dns952table[int32('_')] = -int32('-')
+}
+
+// mangle the given name to be compliant as a DNS952 name "component".
+// the returned result should match the regexp:
+//    ^[a-z]([-a-z0-9]*[a-z0-9])?$
+// returns "" if the name cannot be mangled.
+func AsDNS952(name string) string {
+	if name == "" {
+		return ""
+	}
+	sz := len(name)
+	if sz > DNS952MaxLength {
+		sz = DNS952MaxLength
+	}
+	last := sz - 1
+	label := make([]byte, sz, sz)
+	ll := 0
+	la := -1 // index of last alphanumeric
+	for _, c := range name {
+		b := dns952table[uint8(c)]
+		switch {
+		case b == -int32('-'):
+			if ll == 0 || ll == last {
+				continue
+			}
+			b = -b
+		case b < 0:
+			if ll == 0 {
+				continue
+			}
+			b = -b
+			la = ll
+		case b > 0:
+			la = ll
+		default:
+			continue
+		}
+		label[ll] = byte(b)
+		ll++
+		if ll == sz {
+			break
+		}
+	}
+	if ll > 0 && label[ll-1] == '-' {
+		ll = la + 1
+	}
+	if ll > 0 {
+		return string(label[:ll])
+	}
+	return ""
+}

--- a/records/labels/dns952_test.go
+++ b/records/labels/dns952_test.go
@@ -1,0 +1,48 @@
+package labels
+
+import (
+	"testing"
+)
+
+func BenchmarkAsDNS952(b *testing.B) {
+	const (
+		original = "89f.gsf---g_7-fgs--d7fddg-"
+		expected = "f-gsf---g-7-fgs--d7fddg"
+	)
+
+	// run the AsDNS952 func b.N times
+	for n := 0; n < b.N; n++ {
+		if actual := AsDNS952(original); actual != expected {
+			b.Fatalf("expected %q instead of %q", expected, actual)
+		}
+	}
+}
+
+func TestAsDNS952(t *testing.T) {
+	tests := map[string]string{
+		"":                                "",
+		"a":                               "a",
+		"-":                               "",
+		"a---":                            "a",
+		"---a---":                         "a",
+		"---a---b":                        "a---b",
+		"a.b.c.d.e":                       "a-b-c-d-e",
+		"a.c.d_de.":                       "a-c-d-de",
+		"abc123":                          "abc123",
+		"4abc123":                         "abc123",
+		"-abc123":                         "abc123",
+		"abc123-":                         "abc123",
+		"abc-123":                         "abc-123",
+		"abc--123":                        "abc--123",
+		"fd%gsf---gs7-f$gs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg---123": "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-":      "fdgsf---gs7-fgs--d7fddg",
+	}
+	for untrusted, expected := range tests {
+		actual := AsDNS952(untrusted)
+		if actual != expected {
+			t.Fatalf("expected %q instead of %q after converting %q", expected, actual, untrusted)
+		}
+	}
+}

--- a/records/labels/domfrag.go
+++ b/records/labels/domfrag.go
@@ -1,0 +1,41 @@
+package labels
+
+// mangles the given name in order to produce a valid domain fragment.
+// a valid domain fragment will consist of one or more dns952 labels
+// concatenated by a '.' char.
+func AsDomainFrag(name string) string {
+	if name == "" {
+		return ""
+	}
+	sz := len(name)
+	frag := make([]byte, sz, sz)
+	ll := 0  // overall fragment length so far
+	li := -1 // last fragment we found ended here
+	for i, c := range name {
+		if c == '.' {
+			if f := AsDNS952(name[li+1 : i]); f != "" {
+				if li > -1 {
+					frag[ll] = '.'
+					ll++
+				}
+				// len(f) is <= len(slice-of-name)
+				copy(frag[ll:], f)
+				ll += len(f)
+				li = i
+			}
+		}
+	}
+	// final frag
+	if f := AsDNS952(name[li+1:]); f != "" {
+		if li > -1 {
+			frag[ll] = '.'
+			ll++
+		}
+		copy(frag[ll:], f)
+		ll += len(f)
+	}
+	if ll > 0 {
+		return string(frag[:ll])
+	}
+	return ""
+}

--- a/records/labels/domfrag_test.go
+++ b/records/labels/domfrag_test.go
@@ -1,0 +1,41 @@
+package labels
+
+import (
+	"testing"
+)
+
+func TestAsDomainFrag(t *testing.T) {
+	cases := map[string]string{
+		"":          "",
+		".":         "",
+		"..":        "",
+		"...":       "",
+		"a":         "a",
+		"abc":       "abc",
+		"abc.":      "abc",
+		".abc":      "abc",
+		"a.c":       "a.c",
+		".a.c":      "a.c",
+		"a.c.":      "a.c",
+		"a..c":      "a.c",
+		"ab.c":      "ab.c",
+		"ab.cd":     "ab.cd",
+		"ab.cd.efg": "ab.cd.efg",
+		"a.c.e":     "a.c.e",
+		"a..c.e":    "a.c.e",
+		"a.c..e":    "a.c.e",
+		"pod_123$abc.marathon-0.6.0-dev.mesos": "pod-123abc.marathon-0.dev.mesos",
+		"host.com":                             "host.com",
+		"space space.com":                      "spacespace.com",
+		"blah-dash.com":                        "blah-dash.com",
+		"not$1234.com":                         "not1234.com",
+		"(@ host . com":                        "host.com",
+		"MiXeDcase.CoM":                        "mixedcase.com",
+	}
+	for orig, exp := range cases {
+		act := AsDomainFrag(orig)
+		if act != exp {
+			t.Fatalf("expected %q instead of %q for case %q", exp, act, orig)
+		}
+	}
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -160,7 +160,7 @@ func TestHandler(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// test A records
-	msg, err = fakeQuery("chronos.marathon-0.6.0.mesos.", dns.TypeA, "udp")
+	msg, err = fakeQuery("chronos.marathon-0.mesos.", dns.TypeA, "udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -171,7 +171,7 @@ func TestHandler(t *testing.T) {
 
 	// Test case sensitivity -- this test depends on one above
 	msg_a := msg
-	msg, err = fakeQuery("cHrOnOs.MARATHON-0.6.0.mesoS.", dns.TypeA, "udp")
+	msg, err = fakeQuery("cHrOnOs.MARATHON-0.mesoS.", dns.TypeA, "udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -181,7 +181,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// test SRV record
-	msg, err = fakeQuery("_liquor-store._udp.marathon-0.6.0.mesos.", dns.TypeSRV, "udp")
+	msg, err = fakeQuery("_liquor-store._udp.marathon-0.mesos.", dns.TypeSRV, "udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -211,7 +211,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// test tcp
-	msg, err = fakeQuery("chronos.marathon-0.6.0.mesos.", dns.TypeA, "tcp")
+	msg, err = fakeQuery("chronos.marathon-0.mesos.", dns.TypeA, "tcp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -221,7 +221,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// test AAAA --> NODATA
-	m, err = fakeMsg("chronos.marathon-0.6.0.mesos.", dns.TypeAAAA, "udp")
+	m, err = fakeMsg("chronos.marathon-0.mesos.", dns.TypeAAAA, "udp")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
change generation of SRV records like this:
```
 _apiserver.core.km._tcp.marathon.mesos.: apiserver.core.km-s0.marathon.mesos.:31000
```

to
```
 _apiserver-core-km._tcp.marathon.mesos.: apiserver.core.km-s0.marathon.mesos.:31000
```