### PR TITLE
sanitized task names should make for good SRV service labels

### DIFF
--- a/records/config.go
+++ b/records/config.go
@@ -46,16 +46,16 @@ type Config struct {
 	File string
 
 	// SOA record fields (see http://tools.ietf.org/html/rfc1035#page-18)
-	SOAMname   string  // primary name server
-	SOARname   string  // email of admin esponsible 
-	SOASerial  uint32  // initial version number (incremented on refresh)
-	SOARefresh uint32  // refresh interval
-	SOARetry   uint32  // retry interval 
-	SOAExpire  uint32  // expiration time
-	SOAMinttl  uint32  // minimum TTL
+	SOAMname   string // primary name server
+	SOARname   string // email of admin esponsible
+	SOASerial  uint32 // initial version number (incremented on refresh)
+	SOARefresh uint32 // refresh interval
+	SOARetry   uint32 // retry interval
+	SOAExpire  uint32 // expiration time
+	SOAMinttl  uint32 // minimum TTL
 
 	// Value of RecursionAvailable for responses in Mesos domain
-	RecurseOn bool 
+	RecurseOn bool
 
 	// ListenAddr is the server listener address
 	Listener string
@@ -81,18 +81,18 @@ func SetConfig(cjson string) (c Config) {
 		Port:           53,
 		Timeout:        5,
 		SOARname:       "root.ns1.mesos",
-	        SOAMname:       "ns1.mesos",
-	        SOARefresh:     60,
-	        SOARetry:       600,
-	        SOAExpire:      86400,
-	        SOAMinttl:      60,
+		SOAMname:       "ns1.mesos",
+		SOARefresh:     60,
+		SOARetry:       600,
+		SOAExpire:      86400,
+		SOAMinttl:      60,
 		Resolvers:      []string{"8.8.8.8"},
 		Listener:       "0.0.0.0",
 		HttpPort:       8123,
 		DnsOn:          true,
 		HttpOn:         true,
-	        ExternalOn:     true,
-	        RecurseOn:      true,
+		ExternalOn:     true,
+		RecurseOn:      true,
 	}
 
 	// read configuration file
@@ -143,7 +143,7 @@ func SetConfig(cjson string) (c Config) {
 		c.SOAMname = c.SOAMname + "."
 	}
 	c.SOASerial = uint32(time.Now().Unix())
-	
+
 	// print configuration file
 	logging.Verbose.Println("Mesos-DNS configuration:")
 	if len(c.Masters) != 0 {

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -74,35 +74,6 @@ func TestLeaderIP(t *testing.T) {
 	}
 }
 
-type invalidHosts struct {
-	host     string
-	expected string
-}
-
-func TestStripInvalid(t *testing.T) {
-
-	var tests = []invalidHosts{
-		{"host.com", "host.com"},
-		{"space space.com", "spacespace.com"},
-		{"blah-dash.com", "blah-dash.com"},
-		{"not$1234.com", "not1234.com"},
-		{"(@ host . com", "host.com"},
-		{"MiXeDcase.CoM", "mixedcase.com"},
-	}
-
-	for _, pair := range tests {
-		url := stripInvalid(pair.host)
-		if url != pair.expected {
-			t.Error(
-				"For", pair.host,
-				"expected", pair.expected,
-				"got", url,
-			)
-		}
-	}
-
-}
-
 // ensure we are parsing what we think we are
 func TestInsertState(t *testing.T) {
 
@@ -170,7 +141,7 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// ensure we translate the framework name as well
-	_, ok = rg.As["some-box.chronoswithaspaceandmixedcase-2.0.1.mesos."]
+	_, ok = rg.As["some-box.chronoswithaspaceandmixe.mesos."]
 	if !ok {
 		t.Error("should find this task w/a space in the framework name - A record")
 	}

--- a/records/labels/dns952.go
+++ b/records/labels/dns952.go
@@ -1,0 +1,72 @@
+package labels
+
+const DNS952MaxLength int = 24
+
+var dns952table []int32
+
+func init() {
+	const tolower = int32('a' - 'A')
+	dns952table = make([]int32, 256, 256)
+	for i := int32('A'); i < int32('Z'); i++ {
+		dns952table[i] = i + tolower
+	}
+	for i := int32('a'); i < int32('z'); i++ {
+		dns952table[i] = i
+	}
+	for i := int32('0'); i < int32('9'); i++ {
+		dns952table[i] = -i
+	}
+	dns952table[int32('-')] = -int32('-')
+	dns952table[int32('.')] = -int32('-')
+	dns952table[int32('_')] = -int32('-')
+}
+
+// mangle the given name to be compliant as a DNS952 name "component".
+// the returned result should match the regexp:
+//    ^[a-z]([-a-z0-9]*[a-z0-9])?$
+// returns "" if the name cannot be mangled.
+func AsDNS952(name string) string {
+	if name == "" {
+		return ""
+	}
+	sz := len(name)
+	if sz > DNS952MaxLength {
+		sz = DNS952MaxLength
+	}
+	last := sz - 1
+	label := make([]byte, sz, sz)
+	ll := 0
+	la := -1 // index of last alphanumeric
+	for _, c := range name {
+		b := dns952table[uint8(c)]
+		switch {
+		case b == -int32('-'):
+			if ll == 0 || ll == last {
+				continue
+			}
+			b = -b
+		case b < 0:
+			if ll == 0 {
+				continue
+			}
+			b = -b
+			la = ll
+		case b > 0:
+			la = ll
+		default:
+			continue
+		}
+		label[ll] = byte(b)
+		ll++
+		if ll == sz {
+			break
+		}
+	}
+	if ll > 0 && label[ll-1] == '-' {
+		ll = la + 1
+	}
+	if ll > 0 {
+		return string(label[:ll])
+	}
+	return ""
+}

--- a/records/labels/dns952_test.go
+++ b/records/labels/dns952_test.go
@@ -1,0 +1,48 @@
+package labels
+
+import (
+	"testing"
+)
+
+func BenchmarkAsDNS952(b *testing.B) {
+	const (
+		original = "89f.gsf---g_7-fgs--d7fddg-"
+		expected = "f-gsf---g-7-fgs--d7fddg"
+	)
+
+	// run the AsDNS952 func b.N times
+	for n := 0; n < b.N; n++ {
+		if actual := AsDNS952(original); actual != expected {
+			b.Fatalf("expected %q instead of %q", expected, actual)
+		}
+	}
+}
+
+func TestAsDNS952(t *testing.T) {
+	tests := map[string]string{
+		"":                                "",
+		"a":                               "a",
+		"-":                               "",
+		"a---":                            "a",
+		"---a---":                         "a",
+		"---a---b":                        "a---b",
+		"a.b.c.d.e":                       "a-b-c-d-e",
+		"a.c.d_de.":                       "a-c-d-de",
+		"abc123":                          "abc123",
+		"4abc123":                         "abc123",
+		"-abc123":                         "abc123",
+		"abc123-":                         "abc123",
+		"abc-123":                         "abc-123",
+		"abc--123":                        "abc--123",
+		"fd%gsf---gs7-f$gs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg---123": "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-":      "fdgsf---gs7-fgs--d7fddg",
+	}
+	for untrusted, expected := range tests {
+		actual := AsDNS952(untrusted)
+		if actual != expected {
+			t.Fatalf("expected %q instead of %q after converting %q", expected, actual, untrusted)
+		}
+	}
+}

--- a/records/labels/domfrag.go
+++ b/records/labels/domfrag.go
@@ -1,0 +1,41 @@
+package labels
+
+// mangles the given name in order to produce a valid domain fragment.
+// a valid domain fragment will consist of one or more dns952 labels
+// concatenated by a '.' char.
+func AsDomainFrag(name string) string {
+	if name == "" {
+		return ""
+	}
+	sz := len(name)
+	frag := make([]byte, sz, sz)
+	ll := 0  // overall fragment length so far
+	li := -1 // last fragment we found ended here
+	for i, c := range name {
+		if c == '.' {
+			if f := AsDNS952(name[li+1 : i]); f != "" {
+				if li > -1 {
+					frag[ll] = '.'
+					ll++
+				}
+				// len(f) is <= len(slice-of-name)
+				copy(frag[ll:], f)
+				ll += len(f)
+				li = i
+			}
+		}
+	}
+	// final frag
+	if f := AsDNS952(name[li+1:]); f != "" {
+		if li > -1 {
+			frag[ll] = '.'
+			ll++
+		}
+		copy(frag[ll:], f)
+		ll += len(f)
+	}
+	if ll > 0 {
+		return string(frag[:ll])
+	}
+	return ""
+}

--- a/records/labels/domfrag_test.go
+++ b/records/labels/domfrag_test.go
@@ -1,0 +1,41 @@
+package labels
+
+import (
+	"testing"
+)
+
+func TestAsDomainFrag(t *testing.T) {
+	cases := map[string]string{
+		"":          "",
+		".":         "",
+		"..":        "",
+		"...":       "",
+		"a":         "a",
+		"abc":       "abc",
+		"abc.":      "abc",
+		".abc":      "abc",
+		"a.c":       "a.c",
+		".a.c":      "a.c",
+		"a.c.":      "a.c",
+		"a..c":      "a.c",
+		"ab.c":      "ab.c",
+		"ab.cd":     "ab.cd",
+		"ab.cd.efg": "ab.cd.efg",
+		"a.c.e":     "a.c.e",
+		"a..c.e":    "a.c.e",
+		"a.c..e":    "a.c.e",
+		"pod_123$abc.marathon-0.6.0-dev.mesos": "pod-123abc.marathon-0.dev.mesos",
+		"host.com":                             "host.com",
+		"space space.com":                      "spacespace.com",
+		"blah-dash.com":                        "blah-dash.com",
+		"not$1234.com":                         "not1234.com",
+		"(@ host . com":                        "host.com",
+		"MiXeDcase.CoM":                        "mixedcase.com",
+	}
+	for orig, exp := range cases {
+		act := AsDomainFrag(orig)
+		if act != exp {
+			t.Fatalf("expected %q instead of %q for case %q", exp, act, orig)
+		}
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -121,7 +121,7 @@ func (res *Resolver) Reload() {
 	err := t.ParseState(currentLeader, res.config)
 
 	if err == nil {
-		timestamp :=  uint32(time.Now().Unix())
+		timestamp := uint32(time.Now().Unix())
 		// may need to refactor for fairness
 		res.rsLock.Lock()
 		defer res.rsLock.Unlock()
@@ -248,11 +248,9 @@ func (res *Resolver) formatNS(dom string) (*dns.NS, error) {
 			Class:  dns.ClassINET,
 			Ttl:    ttl,
 		},
-		Ns:      res.config.SOAMname,
+		Ns: res.config.SOAMname,
 	}, nil
 }
-
-
 
 // reorders answers for very basic load balancing
 func shuffleAnswers(answers []dns.RR) []dns.RR {
@@ -286,7 +284,7 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 		if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
 			proto = "tcp"
 		}
-		
+
 		for _, resolver := range res.config.Resolvers {
 			nameserver := resolver + ":53"
 			m, err = res.resolveOut(r, nameserver, proto, recurseCnt)
@@ -295,7 +293,7 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 			}
 		}
 	}
-		
+
 	// resolveOut returns nil Msg sometimes cause of perf
 	if m == nil {
 		m = new(dns.Msg)
@@ -314,7 +312,7 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 			logging.CurLog.NonMesosSuccess.Inc()
 		}
 	}
-	
+
 	err = w.WriteMsg(m)
 	if err != nil {
 		logging.Error.Println(err)
@@ -374,7 +372,7 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// SOA requests
-	if (qType == dns.TypeSOA)  || (qType == dns.TypeANY) {
+	if (qType == dns.TypeSOA) || (qType == dns.TypeANY) {
 		rr, err := res.formatSOA(r.Question[0].Name)
 		if err != nil {
 			logging.Error.Println(err)
@@ -384,7 +382,7 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// NS requests
-	if (qType == dns.TypeNS)  || (qType == dns.TypeANY) {
+	if (qType == dns.TypeNS) || (qType == dns.TypeANY) {
 		rr, err := res.formatNS(r.Question[0].Name)
 		logging.Error.Println("NS request")
 		if err != nil {
@@ -410,7 +408,7 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 
 	} else {
 		// no answers but not a {SOA,SRV} request
-		if len(m.Answer) == 0 && (qType != dns.TypeSOA)  && (qType != dns.TypeNS) && (qType != dns.TypeSRV) {
+		if len(m.Answer) == 0 && (qType != dns.TypeSOA) && (qType != dns.TypeNS) && (qType != dns.TypeSRV) {
 			// set NXDOMAIN
 			m.SetRcode(r, 3)
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -67,16 +67,16 @@ func TestShuffleAnswers(t *testing.T) {
 func fakeDNS(port int) (Resolver, error) {
 	var res Resolver
 	res.config = records.Config{
-		Masters:   []string{"144.76.157.37:5050"},
-		TTL:       60,
-		Port:      port,
-		Domain:    "mesos",
-		Resolvers: records.GetLocalDNS(),
-		Listener:  "127.0.0.1",
-		SOARname:  "root.ns1.mesos.",
-		SOAMname:  "ns1.mesos.",
-		HttpPort:  8123,
-	        ExternalOn: true,
+		Masters:    []string{"144.76.157.37:5050"},
+		TTL:        60,
+		Port:       port,
+		Domain:     "mesos",
+		Resolvers:  records.GetLocalDNS(),
+		Listener:   "127.0.0.1",
+		SOARname:   "root.ns1.mesos.",
+		SOAMname:   "ns1.mesos.",
+		HttpPort:   8123,
+		ExternalOn: true,
 	}
 
 	b, err := ioutil.ReadFile("../factories/fake.json")
@@ -198,7 +198,6 @@ func TestHandler(t *testing.T) {
 	if m.Ns == nil {
 		t.Error("not serving up NS")
 	}
-
 
 	// test non-existing host
 	m, err = fakeMsg("missing.mesos.", dns.TypeA, "udp")


### PR DESCRIPTION
continuation of changes from #127 but applied to the http branch, and with framework name mangling