### PR TITLE
WIP: Add DiscoveryInfo and custom domain name support

### DIFF
--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -29,7 +29,8 @@ The configuration file should include the following fields:
   "SOARetry":   600,
   "SOAExpire":  86400,
   "SOAMinttl": 60,
-  "IPSources": ["mesos", "host"]
+  "IPSources": ["mesos", "host"],
+  "templates": ["{name}.{framework}"]
 }
 ```
 
@@ -74,3 +75,5 @@ It is sufficient to specify just one of the `zk` or `masters` field. If both are
 `recurseon` controls if the DNS replies for names in the Mesos domain will indicate that recursion is available. The default value is `true`. 
 
 `enforceRFC952` will enforce an older, more strict set of rules for DNS labels. For details, see the [RFC-952](https://tools.ietf.org/html/rfc952). The default value is `false`.
+
+`templates` is a list of domain name templates used to create records. The default value is `["{name}.{framework}"]`, compare the [naming documentation](naming.md).

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -64,7 +64,7 @@ For example, a query of the A records for `search.marathon.slave.mesos` would yi
 - `MesosContainerizer.NetworkSettings.IPAddress`.
 
 In general support for these will not be available before Mesos 0.24.
- 
+
 ## SRV Records
 
 An SRV record associates a service name to a hostname and an IP port.
@@ -85,7 +85,7 @@ $ dig _search._tcp.marathon.mesos SRV
 
 ;; ANSWER SECTION:
 _search._tcp.marathon.mesos.	60 IN SRV 0 0 31302 10.254.132.41.
-``` 
+```
 
 Mesos-DNS supports the use of a task's DiscoveryInfo for SRV record generation.
 If no DiscoveryInfo is available then Mesos-DNS will fall back to those "ports" resources allocated for the task.
@@ -113,6 +113,53 @@ Also note that there is inherent delay between the election of a new master and 
 Mesos-DNS generates A records for itself that list all the IP addresses that Mesos-DNS is listening to. The name for Mesos-DNS can be selected using the `SOARname` [configuration parameter](configuration-parameters.html). The default name is `ns1.mesos`. 
 
 In addition to A and SRV records for Mesos tasks, Mesos-DNS supports requests for SOA and NS records for the Mesos domain. DNS requests for records of other types in the Mesos domain will return `NXDOMAIN`. Mesos-DNS does not support PTR records needed fo reserve lookups. 
+
+## Customization of Records
+
+Mesos-DNS allows customization of the list of *record templates* that are used 
+to generate the A record names for each task. Compare the `Template` 
+configuration setting in the [configuration parameter documentation](configuration-parameters.md).
+
+By default only one *record template* is used:
+
+```
+{name}.{framework}
+```
+
+This gives the A records described above, e.g. `nginx.marathon.mesos.`.
+
+Additional templates can be defined using a number of *template variables*. These exist for every task:
+
+- `framework`: the framework name, e.g. `marathon`
+- `slave-id-short`: the number in the slave ID after the last dash `-`, e.g. `0` for a slave ID `20140803-125133-3041283216-5050-2410-0`
+- `slave-id`: the complete slave ID, e.g. `20140803-125133-3041283216-5050-2410-0`
+- `task-id`: the complate task ID, e.g. `chronos.49b91a9a-3dda-11e4-a088-c20493233aa5`
+- `task-id-hash`: a hash value of the task ID, e.g. 76830, sufficiently unique for a realistic number of tasks on a cluster
+- `name`: the name of a task, provided by the framework in the *DiscoveryInfo*, falling back to the name in the *TaskInfo*, e.g. `nginx`
+
+In addition there are a number of optional *template variables* which may be provided by the framework to Mesos in the *DiscoveryInfo* field of a task:
+
+- `version`: the version of a task, provided by the framework in the *DiscoveryInfo*, e.g. `1.0`
+- `location`: the location of a task, provider by the framework in the *DiscoveryInfo*, e.g. `europe`
+- `environment`: the environment of a task, provider by the framework in the *DiscoveryInfo*, e.g. `prod`
+- `label:<key>`: the value for the given label key, provided by the framework in the *DiscoveryInfo*, e.g. label key `canary` with label value `lanzarote`
+
+A *record template* is a string with the condition that after substitution of all *variable references* with a constant string `a` the resulting string is a valid domain name.
+
+A *variable references* is a string matching the regular expression `{\s*<template variable>\s*}`
+where `<template variable>` is any of the *template variable* identifiers from 
+above.
+
+Mesos-DNS will interpolate the given list of *record templates* for each running
+task in the cluster. If a *referenced variable is not defined* or the value is
+the empty string, the record *will not be created*.
+
+Examples:
+- `{name}.{framework}` gives e.g. `nginx.marathon.mesos`.
+- `{name}.{location}.{framework}` gives e.g. `nginx.europe.marathon.mesos`, or no record at all for those tasks that don't define the location.
+- `{version}.{name}.{framework}` gives e.g. `1.0.nginx.marathon.mesos`, or no record at all for those tasks that don't define the version.
+- `{label:canary}.{name}` gives e.g. `lanzarote.nginx.mesos`.
+- `{label:unknown}.{name}` will give no record at all, if no label `unknown` is provided by the framework.
 
 ## Notes
 

--- a/records/config.go
+++ b/records/config.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records/tmpl"
+
 	"github.com/miekg/dns"
 )
 
@@ -76,6 +78,9 @@ type Config struct {
 
 	// IPSources is the prioritized list of task IP sources
 	IPSources []string // e.g. ["host", "docker", "mesos", "rkt"]
+
+	// Templates are text/template style templates for A-records of Mesos tasks
+	Templates []tmpl.Template
 }
 
 // NewConfig return the default config of the resolver
@@ -100,6 +105,7 @@ func NewConfig() Config {
 		ExternalOn:     true,
 		RecurseOn:      true,
 		IPSources:      []string{"mesos", "host"},
+		Templates:		tmpl.DefaultTemplates(),
 	}
 }
 
@@ -166,6 +172,7 @@ func SetConfig(cjson string) Config {
 	logging.Verbose.Println("   - ConfigFile: ", c.File)
 	logging.Verbose.Println("   - EnforceRFC952: ", c.EnforceRFC952)
 	logging.Verbose.Println("   - IPSources: ", c.IPSources)
+	logging.Verbose.Printf("   - Templates: %+v", c.Templates)
 
 	return *c
 }

--- a/records/tmpl/templates.go
+++ b/records/tmpl/templates.go
@@ -1,0 +1,199 @@
+// Package tmpl contains types to compile and interpolate name templates
+// with a given context.
+package tmpl
+
+import (
+	"bytes"
+	"fmt"
+
+	"regexp"
+	"strings"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records/labels"
+)
+
+type (
+	// Context is the namespace to resolve Name template variables in.
+	Context map[string]string
+
+	// Template holds a text/template style tempalte for a DNS name.
+	Template string
+
+	// Compiled is a compiled Template that can be executed efficiently
+	Compiled struct {
+		Template
+		tokens []token
+	}
+
+	token interface {
+		interpolate(Context) (string, error)
+		isSeparator() bool
+	}
+
+	separatorToken struct{}
+	stringToken    string
+	variableToken  string
+)
+
+// DefaultTemplates returns a the default name templates.
+func DefaultTemplates() []Template { return []Template{"{name}.{framework}"} }
+
+// validPartialLabel checks the validity of a partial label according the RFC, depending on the position
+// of the partial label in the current block between two variables and the position in the whole pattern.
+func validPartialLabel(s string, firstInBlock, lastInBlock, firstInPattern, lastInPattern bool, spec labels.Func) bool {
+	// special case for valid underscores: trim them for spec comparison below
+	labelWithoutValidUnderscore := s
+	if (s[0] == '_' && s != "_") || (s == "_" && !lastInPattern) {
+		labelWithoutValidUnderscore = strings.TrimLeft(s, "_")
+	}
+
+	// prepend or append some character to check for RFC compatibility for non-inner labels.
+	//
+	// But don't do this if there is no variableToken on the left or the right, i.e. these
+	// tokens are the most left or the most right ones in the template.
+	pre := ""
+	post := ""
+	if firstInBlock && !firstInPattern {
+		pre = "a"
+	}
+	if lastInBlock && !lastInPattern {
+		post = "a"
+	}
+
+	escapedLabel := spec(pre + labelWithoutValidUnderscore + post)
+	return pre+labelWithoutValidUnderscore+post == escapedLabel
+}
+
+// addNonVariableTokens splits the given string s into partial labels and adds
+// tokens for them. It accepts labels with "_" depending on whether s is in the
+// left or right most position in the whole pattern.
+func addNonVariableTokens(tokens []token, s string, firstInPattern, lastInPattern bool, spec labels.Func) ([]token, error) {
+	if s == "" {
+		return tokens, nil
+	}
+
+	if s == "." {
+		tokens = append(tokens, separatorToken{})
+		return tokens, nil
+	}
+
+	labels := strings.Split(s, ".")
+	for i, label := range labels {
+		firstInBlock := i == 0            // first partial label in a block between variables or the pattern start/end
+		lastInBlock := i == len(labels)-1 // last partial label in a block between variables or the pattern start/end
+
+		if i != 0 {
+			tokens = append(tokens, separatorToken{})
+		}
+
+		// "" and first or last => . at the left or right of s, skip empty string
+		if label == "" && (firstInBlock || lastInBlock) {
+			continue
+		}
+
+		// "" and not the first or last => consecutive separators
+		if label == "" && !firstInBlock && !lastInBlock {
+			return nil, fmt.Errorf("invalid consecutive separators")
+		}
+
+		if !validPartialLabel(label, i == 0, i == len(labels)-1, firstInPattern, lastInPattern, spec) {
+			return nil, fmt.Errorf("template substring %v is no valid label", label)
+		}
+		tokens = append(tokens, stringToken(label))
+	}
+	return tokens, nil
+}
+
+// Compile compiles a Template to a fast Compiled template.
+func (t Template) Compile(spec labels.Func) (*Compiled, error) {
+	tokens := []token{}
+
+	if string(t) == "" {
+		return nil, fmt.Errorf("invalid empty template")
+	}
+
+	// split template into tokens: strings, separators and {variables}
+	varRE, err := regexp.Compile(`{[\s\w-:]*}`)
+	if err != nil {
+		logging.Error.Fatalf("invalid regular expression for variables in template: %v", err)
+	}
+
+	// find variable references and work through the index list
+	varMatches := varRE.FindAllStringIndex(string(t), -1)
+	oldRight := 0
+	for i, m := range varMatches {
+		// extract variable identifier
+		left := m[0]
+		right := m[1]
+		identifier := strings.Trim(string(t)[left+1:right-1], " \t")
+		if identifier == "" {
+			return nil, fmt.Errorf("empty variable reference found in template %v", t)
+		}
+
+		// create token for everything in front of the variable
+		leftMost := i == 0
+		tokens, err = addNonVariableTokens(tokens, string(t)[oldRight:left], leftMost, false, spec)
+		if err != nil {
+			return nil, fmt.Errorf("invalid template %v: %v", t, err)
+		}
+
+		// add the actual variable token
+		tokens = append(tokens, variableToken(identifier))
+
+		// prepare for next round
+		oldRight = right
+	}
+
+	// add pending tokens behind the last variable
+	leftMost := len(varMatches) == 0
+	rightMost := true
+	tokens, err = addNonVariableTokens(tokens, string(t)[oldRight:len(t)], leftMost, rightMost, spec)
+	if err != nil {
+		return nil, fmt.Errorf("invalid template %v: %v", t, err)
+	}
+
+	// check that the first and the last token is not a separator
+	if tokens[0].isSeparator() {
+		return nil, fmt.Errorf("template cannot start with a dot")
+	}
+	if tokens[len(tokens)-1].isSeparator() {
+		return nil, fmt.Errorf("template cannot end with a dot")
+	}
+
+	return &Compiled{
+		Template: t,
+		tokens:   tokens,
+	}, nil
+}
+
+// String returns the template string
+func (t Template) String() string { return string(t) }
+
+// Execute applies a Context to a pre-compiled Template by interpolating
+// the context values using the text.Template syntax.
+func (c *Compiled) Execute(ctx Context) (string, error) {
+	var buffer bytes.Buffer
+	for _, t := range c.tokens {
+		label, err := t.interpolate(ctx)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(label)
+	}
+	return buffer.String(), nil
+}
+
+func (separatorToken) interpolate(Context) (string, error) { return ".", nil }
+func (t stringToken) interpolate(Context) (string, error)  { return string(t), nil }
+func (t variableToken) interpolate(ctx Context) (string, error) {
+	value := ctx[string(t)]
+	if value == "" {
+		return "", fmt.Errorf("%q is not defined in context %v", t, ctx)
+	}
+	return value, nil
+}
+
+func (separatorToken) isSeparator() bool { return true }
+func (stringToken) isSeparator() bool    { return false }
+func (variableToken) isSeparator() bool  { return false }

--- a/records/tmpl/templates_test.go
+++ b/records/tmpl/templates_test.go
@@ -1,0 +1,95 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/mesosphere/mesos-dns/records/labels"
+)
+
+func TestCompile(t *testing.T) {
+	for _, ts := range []struct {
+		Template
+		rfc labels.Func
+		err bool
+	}{
+		{"abc", labels.RFC952, false},
+
+		{"", labels.RFC952, true},
+		{".", labels.RFC952, true},
+		{"abc.", labels.RFC952, true},
+		{".abc", labels.RFC952, true},
+		{".abc.", labels.RFC952, true},
+		{".a.b.c.", labels.RFC952, true},
+		{"a..bc", labels.RFC952, true},
+		{"a...bc", labels.RFC952, true},
+		{"1", labels.RFC952, true},
+		{"1.2", labels.RFC952, true},
+		{"-", labels.RFC952, true},
+		{"a-", labels.RFC952, true},
+		{"-a", labels.RFC952, true},
+		{"a.-.b", labels.RFC952, true},
+		{"a:b", labels.RFC952, true},
+
+		{"_abc", labels.RFC952, false},
+		{"_{abc}", labels.RFC952, false},
+		{"_{abc}._tcp.mesos", labels.RFC952, false},
+
+		{"_", labels.RFC952, true},
+		{"a_b", labels.RFC952, true},
+		{"abc_", labels.RFC952, true},
+		{"_{abc}._", labels.RFC952, true},
+
+		{"abc.def.ghi", labels.RFC952, false},
+		{"abc.def123.ghi", labels.RFC952, false},
+	} {
+		_, err := ts.Compile(ts.rfc)
+		if err != nil && !ts.err {
+			t.Errorf("cannot compile template %q: %v", ts.Template, err)
+			continue
+		} else if err == nil && ts.err {
+			t.Errorf("expected error compiling template %q", ts.Template)
+			continue
+		}
+	}
+}
+
+func TestExecute(t *testing.T) {
+	for _, ts := range []struct {
+		Template
+		rfc     labels.Func
+		context Context
+		answer  string
+		err     bool
+	}{
+		{"abc", labels.RFC952, Context{}, "abc", false},
+		{"abc.def", labels.RFC952, Context{}, "abc.def", false},
+		{"abc.def123.ghi.j-k-l", labels.RFC952, Context{}, "abc.def123.ghi.j-k-l", false},
+
+		{"{framework}", labels.RFC952, Context{"framework": "marathon"}, "marathon", false},
+		{"{ framework\t}", labels.RFC952, Context{"framework": "marathon"}, "marathon", false},
+		{"{   \tframework\t \t}", labels.RFC952, Context{"framework": "marathon"}, "marathon", false},
+		{"{framework}.foo", labels.RFC952, Context{"framework": "marathon"}, "marathon.foo", false},
+		{"{name}.{framework}", labels.RFC952, Context{"framework": "marathon", "name": "nginx"}, "nginx.marathon", false},
+		{"{name}-{framework}", labels.RFC952, Context{"framework": "marathon", "name": "nginx"}, "nginx-marathon", false},
+	} {
+		compiled, err := ts.Compile(ts.rfc)
+		if err != nil {
+			t.Errorf("cannot compile template %q: %v", ts.Template, err)
+			continue
+		}
+
+		got, err := compiled.Execute(ts.context)
+		if err != nil && !ts.err {
+			t.Errorf("unexpected execution error for template %v in context %v: %v", ts.Template, ts.context, err)
+			continue
+		} else if err == nil && ts.err {
+			t.Errorf("expected execution error for template %v in context %v: got %v", ts.Template, ts.context, got)
+			continue
+		}
+
+		if got != ts.answer {
+			t.Errorf("invalid answer for template %v in context %v: got %q, want %q", ts.Template, ts.context, got, ts.answer)
+			continue
+		}
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -150,6 +150,7 @@ func (res *Resolver) LaunchZK(initialDetectionTimeout time.Duration) (<-chan str
 // Reload triggers a new state load from the configured Mesos master.
 func (res *Resolver) Reload() {
 	t := records.RecordGenerator{}
+
 	// Being very conservative
 	res.leaderLock.RLock()
 	currentLeader := res.leader

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/records/labels"
 	"github.com/mesosphere/mesos-dns/records/state"
+	"github.com/mesosphere/mesos-dns/records/tmpl"
 	"github.com/miekg/dns"
 )
 
@@ -142,13 +143,13 @@ func TestHandlers(t *testing.T) {
 				header(true, dns.RcodeSuccess),
 				answers(
 					srv(rrheader("_car-store._udp.marathon.mesos.", dns.TypeSRV, 60),
-						"car-store-50548-0.marathon.slave.mesos.", 31365, 0, 0),
+						"car-store-50548-0.marathon.mesos.", 31365, 0, 0),
 					srv(rrheader("_car-store._udp.marathon.mesos.", dns.TypeSRV, 60),
-						"car-store-50548-0.marathon.slave.mesos.", 31364, 0, 0)),
+						"car-store-50548-0.marathon.mesos.", 31364, 0, 0)),
 				extras(
-					a(rrheader("car-store-50548-0.marathon.slave.mesos.", dns.TypeA, 60),
+					a(rrheader("car-store-50548-0.marathon.mesos.", dns.TypeA, 60),
 						net.ParseIP("1.2.3.11")),
-					a(rrheader("car-store-50548-0.marathon.slave.mesos.", dns.TypeA, 60),
+					a(rrheader("car-store-50548-0.marathon.mesos.", dns.TypeA, 60),
 						net.ParseIP("1.2.3.11")))),
 		},
 		{
@@ -443,7 +444,7 @@ func fakeDNS(t *testing.T) *Resolver {
 	}
 
 	spec := labels.RFC952
-	err = res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", res.config.Masters, res.config.IPSources, spec)
+	err = res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", res.config.Masters, res.config.IPSources, tmpl.DefaultTemplates(), spec)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- add domain name `Templates` configuration flag
- create non-canonical records according the domain patterns, interpolated as text/templates
- implement container IP proposal of https://github.com/mesosphere/mesos-dns/pull/197#issuecomment-128594330 (unfinished, see TODO below)

Reasons to implement our own template engine:
- text/template has no error handling for missing values of variables (until 5 months ago, but not in Go 1.3 or 1.4 yet)
- the template syntax is an interface to the user. If text/template causes performance problems (it seems to be pretty central in the record generation and could be very well be the bottleneck), we would not be able to optimize without the burden to fork the complete text/template library. With our own implementation we have full control.
- text/template would not allow easy checking for validity of a template
- text/template implements much more logic than we need, it uses reflection heavily. Overall it feels to be pretty heavy for our small domain name templates.

TODO:
- [x] re-add tests
- [x] drop records with missing context variable values
- [x] fallback from di-name -> name
- [x] document patterns
- [ ] add default values for variables in patterns (maybe follow-up PR)
- [ ] do benchmarks
- [ ] add (d) and (e) of container IP proposal at https://github.com/mesosphere/mesos-dns/pull/197#issuecomment-128594330 (maybe follow-up PR)
- [ ] add support for DiscoveryInfo *visibility* (maybe follow-up PR)
- [ ] use `domainFrag` and friends
- [ ] handle spec returning empty values
- [ ] use better hash function, e.g. `zbase32` (maybe follow-up PR)