### PR TITLE
WIP: Plugins (v2) API Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 default: all
 
-all: restoredeps test build
+all: test build
 
 restoredeps:
 	@echo "--> Restoring build dependencies"

--- a/app.go
+++ b/app.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"time"
+
+	"github.com/emicklei/go-restful"
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/plugins"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/resolver"
+	"github.com/mesosphere/mesos-dns/util"
+)
+
+const (
+	zkInitialDetectionTimeout = 30 * time.Second
+)
+
+type errorHandlerFunc func(string, error)
+
+type app struct {
+	config     records.Config
+	resolver   *resolver.Resolver
+	filters    plugins.FilterSet
+	ready      chan struct{} // when closed, indicates that initialization has completed
+	done       chan struct{} // when closed, indicates that run has completed
+	errHandler errorHandlerFunc
+}
+
+type pluginContext struct {
+	*app
+	pluginName string
+}
+
+func newApp(eh errorHandlerFunc) *app {
+	c := &app{
+		errHandler: eh,
+		ready:      make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	c.initialize()
+	return c
+}
+
+func (c *app) Resolver() plugins.Resolver {
+	return c
+}
+
+func (c *app) Done() <-chan struct{} {
+	// clients that use this chan will block until run completes
+	return c.done
+}
+
+// implements plugin.Resolver interface, panics if invoked outside of initialization process
+func (c *app) OnReload(r resolver.Reloader) {
+	select {
+	case <-c.ready:
+		panic("cannot OnReload after initialization has completed")
+	default:
+		c.resolver.OnReload(r)
+	}
+}
+
+func (c *app) AddFilter(f plugins.Filter) {
+	select {
+	case <-c.ready:
+		panic("cannot AddFilter after initialization has completed")
+	default:
+	}
+	if f != nil {
+		//TODO(jdef) wrap plugin filters to handle plugin panic()s?
+		c.filters = append(c.filters, f)
+	}
+}
+
+func (c *app) RegisterWS(ws *restful.WebService) {
+	select {
+	case <-c.ready:
+		panic("cannot RegisterWS after initialization has completed")
+	default:
+		restful.Add(ws)
+	}
+}
+
+func (c *app) initialize() {
+	select {
+	case <-c.ready:
+		panic("app already initialized")
+	default:
+		defer close(c.ready)
+	}
+
+	c.config = records.SetConfig(*cjson)
+	c.resolver = resolver.New(version, c.config)
+	for _, pconfig := range c.config.Plugins {
+		if pconfig.Name == "" {
+			logging.Error.Printf("failed to register plugin with empty name")
+			continue
+		}
+		plugin, err := plugins.New(pconfig.Name, pconfig.Settings)
+		if err != nil {
+			logging.Error.Printf("failed to create plugin: %v", err)
+			continue
+		}
+		logging.Verbose.Printf("starting plugin %q", pconfig.Name)
+		pctx := &pluginContext{pluginName: pconfig.Name, app: c}
+		plugin.Start(pctx)
+		go func(pluginName string) {
+			select {
+			case <-plugin.Done():
+				logging.Verbose.Printf("plugin %q terminated", pluginName)
+			}
+		}(pconfig.Name)
+	}
+}
+
+func launchServer(enabled bool, f func() <-chan error) (errCh <-chan error) {
+	if enabled {
+		errCh = f()
+	}
+	return
+}
+
+// launch Zookeeper listener
+func (c *app) launchZK() (newLeader <-chan struct{}, zkErr <-chan error) {
+	if c.config.Zk != "" {
+		newLeader, zkErr = c.resolver.LaunchZK(zkInitialDetectionTimeout)
+	} else {
+		// uniform behavior when new leader from masters field
+		leader := make(chan struct{}, 1)
+		leader <- struct{}{}
+		newLeader = leader
+	}
+	return
+}
+
+// periodically reload DNS records, either because the reload timer expired or else
+// because a celler invoked the tryReload func returned by this func.
+func (c *app) launchReloader() (tryReload func()) {
+	// generate reload signal; up to 1 reload pending at any time
+	reloadSignal := make(chan struct{}, 1)
+	tryReload = func() {
+		// non-blocking, attempt to queue a reload
+		select {
+		case reloadSignal <- struct{}{}:
+		default:
+		}
+	}
+
+	// periodic loading of DNS state (pull from Master)
+	go func() {
+		defer util.HandleCrash()
+		reloadTimeout := time.Second * time.Duration(c.config.RefreshSeconds)
+		reloadTimer := time.AfterFunc(reloadTimeout, tryReload)
+		for _ = range reloadSignal {
+			c.resolver.Reload()
+			logging.PrintCurLog()
+			reloadTimer.Reset(reloadTimeout)
+		}
+	}()
+	return
+}
+
+func (c *app) run() {
+	select {
+	case <-c.ready:
+		select {
+		case <-c.done:
+			panic("run already completed")
+		default:
+			defer close(c.done)
+		}
+	default:
+		panic("cannot run, not yet initialized")
+	}
+
+	// launch async server procs
+	dnsErr := launchServer(c.config.DnsOn, c.resolver.LaunchDNS)
+	httpErr := launchServer(c.config.HttpOn, c.resolver.LaunchHTTP)
+	newLeader, zkErr := c.launchZK()
+	tryReload := c.launchReloader()
+
+	// infinite loop until there is fatal error
+	// TODO(jdef) it would be nice to extend error handling to plugins
+	for {
+		select {
+		case <-newLeader:
+			tryReload()
+		case err := <-dnsErr:
+			c.errHandler("DNS server", err)
+		case err := <-httpErr:
+			c.errHandler("HTTP server", err)
+		case err := <-zkErr:
+			c.errHandler("ZK watcher", err)
+		}
+	}
+}

--- a/app.go
+++ b/app.go
@@ -80,6 +80,17 @@ func (c *app) RegisterWS(ws *restful.WebService) {
 	}
 }
 
+// return a clone of the global configuration, minus any plugin-specific JSON
+func (c *app) Config() *records.Config {
+	cfg := c.config
+	cfg.Plugins = nil
+	cfg.Masters = make([]string, len(c.config.Masters))
+	copy(cfg.Masters, c.config.Masters)
+	cfg.Resolvers = make([]string, len(c.config.Resolvers))
+	copy(cfg.Resolvers, c.config.Resolvers)
+	return &cfg
+}
+
 func (c *app) initialize() {
 	select {
 	case <-c.ready:

--- a/app.go
+++ b/app.go
@@ -44,7 +44,7 @@ func newApp(eh errorHandlerFunc) *app {
 	return c
 }
 
-func (c *app) Resolver() plugins.Resolver {
+func (c *app) Events() plugins.RecordEvents {
 	return c
 }
 
@@ -53,8 +53,8 @@ func (c *app) Done() <-chan struct{} {
 	return c.done
 }
 
-// implements plugin.Resolver interface, panics if invoked outside of initialization process
-func (c *app) OnPreload(r plugins.Reloader) {
+// implements plugin.RecordEvents interface, panics if invoked outside of initialization process
+func (c *app) OnPreload(r plugins.RecordLoader) {
 	select {
 	case <-c.ready:
 		panic("cannot OnPreload after initialization has completed")
@@ -63,7 +63,7 @@ func (c *app) OnPreload(r plugins.Reloader) {
 	}
 }
 
-func (c *app) OnPostload(r plugins.Reloader) {
+func (c *app) OnPostload(r plugins.RecordLoader) {
 	select {
 	case <-c.ready:
 		panic("cannot OnPostload after initialization has completed")

--- a/app.go
+++ b/app.go
@@ -51,12 +51,21 @@ func (c *app) Done() <-chan struct{} {
 }
 
 // implements plugin.Resolver interface, panics if invoked outside of initialization process
-func (c *app) OnReload(r plugins.Reloader) {
+func (c *app) OnPreload(r plugins.Reloader) {
 	select {
 	case <-c.ready:
-		panic("cannot OnReload after initialization has completed")
+		panic("cannot OnPreload after initialization has completed")
 	default:
-		c.resolver.OnReload(resolver.Reloader(r))
+		c.resolver.OnPreload(resolver.RecordLoader(r))
+	}
+}
+
+func (c *app) OnPostload(r plugins.Reloader) {
+	select {
+	case <-c.ready:
+		panic("cannot OnPostload after initialization has completed")
+	default:
+		c.resolver.OnPostload(resolver.RecordLoader(r))
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -67,7 +67,6 @@ func (c *app) AddFilter(f plugins.Filter) {
 	default:
 	}
 	if f != nil {
-		//TODO(jdef) wrap plugin filters to handle plugin panic()s?
 		c.filters = append(c.filters, f)
 	}
 }
@@ -174,7 +173,9 @@ func (c *app) run() {
 	}
 
 	// launch async server procs
-	dnsErr := launchServer(c.config.DnsOn, c.resolver.LaunchDNS)
+	dnsErr := launchServer(c.config.DnsOn, func() <-chan error {
+		return c.resolver.LaunchDNS(c.filters.Apply)
+	})
 	httpErr := launchServer(c.config.HttpOn, c.resolver.LaunchHTTP)
 	newLeader, zkErr := c.launchZK()
 	tryReload := c.launchReloader()

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ func main() {
 	// initialize logging
 	logging.SetupLogs()
 
-	// print error and terminate
+	// print error and terminate.
+	// TODO(jdef) this doesn't allow plugins to gracefully terminate
 	eh := func(name string, err error) {
 		if err != nil {
 			logging.Error.Fatalf("%s failed: %v", name, err)

--- a/main.go
+++ b/main.go
@@ -4,16 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/mesosphere/mesos-dns/logging"
-	"github.com/mesosphere/mesos-dns/records"
-	"github.com/mesosphere/mesos-dns/resolver"
 	"github.com/mesosphere/mesos-dns/util"
 )
 
-const (
-	zkInitialDetectionTimeout = 30 * time.Second
+var (
+	cjson       = flag.String("config", "config.json", "path to config file (json)")
+	versionFlag = flag.Bool("version", false, "output the version")
 )
 
 func main() {
@@ -22,15 +20,11 @@ func main() {
 		os.Exit(1)
 	})
 
-	var versionFlag bool
-
 	// parse flags
-	cjson := flag.String("config", "config.json", "path to config file (json)")
-	flag.BoolVar(&versionFlag, "version", false, "output the version")
 	flag.Parse()
 
 	// -version
-	if versionFlag {
+	if *versionFlag {
 		fmt.Println(version)
 		os.Exit(0)
 	}
@@ -38,35 +32,8 @@ func main() {
 	// initialize logging
 	logging.SetupLogs()
 
-	// initialize resolver
-	config := records.SetConfig(*cjson)
-	resolver := resolver.New(version, config)
-
-	var dnsErr, httpErr, zkErr <-chan error
-	var newLeader <-chan struct{}
-
-	// launch DNS server
-	if config.DnsOn {
-		dnsErr = resolver.LaunchDNS()
-	}
-
-	// launch HTTP server
-	if config.HttpOn {
-		httpErr = resolver.LaunchHTTP()
-	}
-
-	// launch Zookeeper listener
-	if config.Zk != "" {
-		newLeader, zkErr = resolver.LaunchZK(zkInitialDetectionTimeout)
-	} else {
-		// uniform behavior when new leader from masters field
-		leader := make(chan struct{}, 1)
-		leader <- struct{}{}
-		newLeader = leader
-	}
-
 	// print error and terminate
-	handleServerErr := func(name string, err error) {
+	eh := func(name string, err error) {
 		if err != nil {
 			logging.Error.Fatalf("%s failed: %v", name, err)
 		} else {
@@ -74,39 +41,7 @@ func main() {
 		}
 	}
 
-	// generate reload signal; up to 1 reload pending at any time
-	reloadSignal := make(chan struct{}, 1)
-	tryReload := func() {
-		// non-blocking, attempt to queue a reload
-		select {
-		case reloadSignal <- struct{}{}:
-		default:
-		}
-	}
-
-	// periodic loading of DNS state (pull from Master)
-	go func() {
-		defer util.HandleCrash()
-		reloadTimeout := time.Second * time.Duration(config.RefreshSeconds)
-		reloadTimer := time.AfterFunc(reloadTimeout, tryReload)
-		for _ = range reloadSignal {
-			resolver.Reload()
-			logging.PrintCurLog()
-			reloadTimer.Reset(reloadTimeout)
-		}
-	}()
-
-	// infinite loop until there is fatal error
-	for {
-		select {
-		case <-newLeader:
-			tryReload()
-		case err := <-dnsErr:
-			handleServerErr("DNS server", err)
-		case err := <-httpErr:
-			handleServerErr("HTTP server", err)
-		case err := <-zkErr:
-			handleServerErr("ZK watcher", err)
-		}
-	}
+	// run mesos-dns
+	app := newApp(eh)
+	app.run()
 }

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/plugins"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/records/config"
+)
+
+type pluginContext struct {
+	*app
+	onPreload  func(config.RecordLoader)
+	onPostload func(config.RecordLoader)
+}
+
+func newPluginContext(c *app, master *config.MasterSource) *pluginContext {
+	return &pluginContext{
+		app:        c,
+		onPreload:  master.OnPreload,
+		onPostload: master.OnPostload,
+	}
+}
+
+func (c *pluginContext) Events() plugins.RecordEvents {
+	return c
+}
+
+func (c *pluginContext) Done() <-chan struct{} {
+	// clients that use this chan will block until run completes
+	return c.done
+}
+
+// implements plugin.RecordEvents interface, panics if invoked outside of initialization process
+func (c *pluginContext) OnPreload(r plugins.RecordLoader) {
+	select {
+	case <-c.ready:
+		panic("cannot OnPreload after initialization has completed")
+	default:
+		c.onPreload(config.RecordLoader(r))
+	}
+}
+
+func (c *pluginContext) OnPostload(r plugins.RecordLoader) {
+	select {
+	case <-c.ready:
+		panic("cannot OnPostload after initialization has completed")
+	default:
+		c.onPostload(config.RecordLoader(r))
+	}
+}
+
+func (c *pluginContext) AddFilter(f plugins.Filter) {
+	select {
+	case <-c.ready:
+		panic("cannot AddFilter after initialization has completed")
+	default:
+	}
+	if f != nil {
+		c.filters = append(c.filters, f)
+	}
+}
+
+func (c *pluginContext) RegisterSource(source string) chan<- interface{} {
+	select {
+	case <-c.ready:
+		panic("cannot RegisterSource after initialization has completed")
+	default:
+		return c.recordConfig.Channel(source)
+	}
+}
+
+func (c *pluginContext) RegisterWS(ws *restful.WebService) {
+	select {
+	case <-c.ready:
+		panic("cannot RegisterWS after initialization has completed")
+	default:
+		restful.Add(ws)
+	}
+}
+
+// return a clone of the global configuration, minus any plugin-specific JSON
+func (c *pluginContext) Config() *records.Config {
+	cfg := c.config
+	cfg.Plugins = nil
+	cfg.Masters = make([]string, len(c.config.Masters))
+	copy(cfg.Masters, c.config.Masters)
+	cfg.Resolvers = make([]string, len(c.config.Resolvers))
+	copy(cfg.Resolvers, c.config.Resolvers)
+	return &cfg
+}
+
+// launch third-party plugins
+func (c *pluginContext) initAddonPlugins() {
+	for _, pconfig := range c.config.Plugins {
+		pluginName := pconfig.Name
+		if pluginName == "" {
+			logging.Error.Printf("failed to register plugin with empty name")
+			continue
+		}
+		plugin, err := plugins.New(pluginName, pconfig.Settings)
+		if err != nil {
+			logging.Error.Printf("failed to create plugin: %v", err)
+			continue
+		}
+		c.launchPlugin(pluginName, plugin)
+	}
+}
+
+func (c *pluginContext) launchPlugin(pluginName string, plugin plugins.Plugin) {
+	logging.Verbose.Printf("starting plugin %q", pluginName)
+	if errCh := plugin.Start(c); errCh != nil {
+		go func() {
+			for err := range errCh {
+				c.errHandler(pluginName, err)
+			}
+		}()
+	}
+	go func() {
+		//TODO(jdef) should plugins be restarted if they fail? might not apply to all plugin types.
+		//could be mitigated via some plugin lifecycle type.
+		select {
+		case <-plugin.Done():
+			logging.Verbose.Printf("plugin %q terminated", pluginName)
+		}
+	}()
+}

--- a/plugins/filters.go
+++ b/plugins/filters.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"github.com/miekg/dns"
+)
+
+// Registers a filter that will be invoked prior to the DNS server handling
+// the request. A filter may decide to handle the request on behalf of the
+// DNS server, in which case the chain is never invoked. To continue processing
+// the request a filter should invoke the chain. The chain will never be nil.
+type Filter interface {
+	ServeDNS(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler)
+}
+
+// Func adapter for the Filter interface.
+type FilterFunc func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler)
+
+func (f FilterFunc) ServeDNS(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+	f(w, r, chain)
+}
+
+type FilterSet []Filter
+
+// Apply this filter set to the given handler func. Filter implementations are not
+// obligated to invoke the chain, so the handler may never actually be called. This
+// particular implementation iterates through the filter set in a LIFO manner.
+func (fs FilterSet) Handler(handler dns.Handler) dns.Handler {
+	index := len(fs)
+	var chain dns.HandlerFunc
+	chain = dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		if index > 0 {
+			index--
+			fs[index].ServeDNS(w, r, chain)
+		} else {
+			handler.ServeDNS(w, r)
+		}
+	})
+	return chain
+}

--- a/plugins/filters.go
+++ b/plugins/filters.go
@@ -24,7 +24,7 @@ type FilterSet []Filter
 // Apply this filter set to the given handler func. Filter implementations are not
 // obligated to invoke the chain, so the handler may never actually be called. This
 // particular implementation iterates through the filter set in a LIFO manner.
-func (fs FilterSet) Handler(handler dns.Handler) dns.Handler {
+func (fs FilterSet) Apply(handler dns.Handler) dns.Handler {
 	index := len(fs)
 	var chain dns.HandlerFunc
 	chain = dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {

--- a/plugins/filters_test.go
+++ b/plugins/filters_test.go
@@ -1,0 +1,162 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestFilters_Empty(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+	filtered := FilterSet(nil).Handler(h)
+	filtered.ServeDNS(nil, nil)
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_Single(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := false
+	filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+		filtered = true
+		if invoked {
+			t.Fatalf("end of chain already invoked")
+		}
+		// continue processing filters
+		chain.ServeDNS(w, r)
+	}))
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered {
+		t.Fatalf("filter not invoked")
+	}
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_SingleAbortive(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := false
+	filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+		filtered = true
+		if invoked {
+			t.Fatalf("end of chain already invoked")
+		}
+		// don't invoke chain, abort processing
+	}))
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered {
+		t.Fatalf("filter not invoked")
+	}
+	if invoked {
+		t.Fatalf("end of filter chain invoked")
+	}
+}
+
+func TestFilters_Multi(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := []bool{false, false, false}
+	for k, _ := range filtered {
+		i := k // don't use a loop var in a callback func
+		filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+			filtered[i] = true
+			if invoked {
+				t.Fatalf("end of chain already invoked")
+			}
+
+			// test LIFO algorithm: "lower" filters should not have been invoked
+			for j := 0; j < i; j++ {
+				if filtered[j] {
+					t.Fatalf("filter invoked out of order")
+				}
+			}
+
+			// continue processing filters
+			chain.ServeDNS(w, r)
+		}))
+	}
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	for i, f := range filtered {
+		if !f {
+			t.Fatalf("filter %d not invoked", i)
+		}
+	}
+	if !invoked {
+		t.Fatalf("end of filter chain not invoked")
+	}
+}
+
+func TestFilters_MultiAbortive(t *testing.T) {
+	invoked := false
+	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		invoked = true
+	})
+
+	var filters FilterSet
+	filtered := []bool{false, false, false}
+	for k, _ := range filtered {
+		i := k // don't use a loop var in a callback func
+		filters = append(filters, FilterFunc(func(w dns.ResponseWriter, r *dns.Msg, chain dns.Handler) {
+			filtered[i] = true
+			if invoked {
+				t.Fatalf("end of chain already invoked")
+			}
+
+			// test LIFO algorithm: "lower" filters should not have been invoked
+			for j := 0; j < i; j++ {
+				if filtered[j] {
+					t.Fatalf("filter invoked out of order")
+				}
+			}
+
+			// abort when i == 1
+			if i != 1 {
+				chain.ServeDNS(w, r)
+			}
+		}))
+	}
+
+	filteredHandler := filters.Handler(h)
+	filteredHandler.ServeDNS(nil, nil)
+
+	if !filtered[2] {
+		t.Fatalf("filter 2 not invoked")
+	}
+	if !filtered[1] {
+		t.Fatalf("filter 1 not invoked")
+	}
+	if filtered[0] {
+		t.Fatalf("filter 0 invoked")
+	}
+	if invoked {
+		t.Fatalf("end of filter chain invoked")
+	}
+}

--- a/plugins/filters_test.go
+++ b/plugins/filters_test.go
@@ -11,7 +11,7 @@ func TestFilters_Empty(t *testing.T) {
 	h := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		invoked = true
 	})
-	filtered := FilterSet(nil).Handler(h)
+	filtered := FilterSet(nil).Apply(h)
 	filtered.ServeDNS(nil, nil)
 	if !invoked {
 		t.Fatalf("end of filter chain not invoked")
@@ -35,7 +35,7 @@ func TestFilters_Single(t *testing.T) {
 		chain.ServeDNS(w, r)
 	}))
 
-	filteredHandler := filters.Handler(h)
+	filteredHandler := filters.Apply(h)
 	filteredHandler.ServeDNS(nil, nil)
 
 	if !filtered {
@@ -62,7 +62,7 @@ func TestFilters_SingleAbortive(t *testing.T) {
 		// don't invoke chain, abort processing
 	}))
 
-	filteredHandler := filters.Handler(h)
+	filteredHandler := filters.Apply(h)
 	filteredHandler.ServeDNS(nil, nil)
 
 	if !filtered {
@@ -101,7 +101,7 @@ func TestFilters_Multi(t *testing.T) {
 		}))
 	}
 
-	filteredHandler := filters.Handler(h)
+	filteredHandler := filters.Apply(h)
 	filteredHandler.ServeDNS(nil, nil)
 
 	for i, f := range filtered {
@@ -144,7 +144,7 @@ func TestFilters_MultiAbortive(t *testing.T) {
 		}))
 	}
 
-	filteredHandler := filters.Handler(h)
+	filteredHandler := filters.Apply(h)
 	filteredHandler.ServeDNS(nil, nil)
 
 	if !filtered[2] {

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,0 +1,90 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/emicklei/go-restful"
+	"github.com/mesosphere/mesos-dns/resolver"
+)
+
+// A plugin has a single use lifecycle: once started, it may be stopped. once stopped,
+// it may not be restarted.
+type Plugin interface {
+	// Performs initialization and starts any requisite background tasks for the plugin.
+	// Pre-server-startup actions such as Filter or resolver.Reloader registration must
+	// be completed before this func returns. This func is not expected to block for long
+	// and should return relatively quickly.
+	Start(Context)
+	// Stops any running background tasks for the plugin, should return immediately.
+	Stop()
+	// Returns a signal chan that's closed once the plugin has terminated.
+	Done() <-chan struct{}
+}
+
+// Build a new instance of a Plugin given some JSON configuration data.
+type Factory func(json.RawMessage) (Plugin, error)
+
+// Plugins use this interface to communicate with the underlying DNS resolver.
+type Resolver interface {
+	OnReload(r resolver.Reloader)
+}
+
+type Context interface {
+	// Return a pointer to the mesos-dns Resolver.
+	Resolver() Resolver
+
+	// Adds a new filter handle some kind of pre- or post-processing of
+	// DNS requests and/or responses.
+	AddFilter(Filter)
+
+	// Register the given plugin REST web service
+	RegisterWS(*restful.WebService)
+
+	// Return a signal chan that closes when the server enters shutdown mode.
+	Done() <-chan struct{}
+}
+
+var (
+	pluginsLock sync.Mutex
+	plugins     = map[string]Factory{}
+)
+
+// Register a new Factory implementation for the given plugin name. Both fields
+// are required and name is not allowed to be empty. It's recommended that names
+// use a domain/label convention, for example "mesos-dns.io/fancyPlugin".
+func Register(name string, f Factory) error {
+	if name == "" {
+		return fmt.Errorf("illegal plugin name")
+	}
+	if f == nil {
+		return fmt.Errorf("nil Factory not allowed")
+	}
+
+	pluginsLock.Lock()
+	defer pluginsLock.Unlock()
+
+	if _, found := plugins[name]; found {
+		return fmt.Errorf("Factory for %q is already registered", name)
+	}
+
+	plugins[name] = f
+	return nil
+}
+
+// Create a new plugin for the registered name and the given JSON configuration.
+// Will return an error if either the name is unregistered or else if the registered
+// factory generates an error attempting to build a new plugin instance.
+func New(name string, raw json.RawMessage) (Plugin, error) {
+	factory, found := func() (f Factory, ok bool) {
+		pluginsLock.Lock()
+		defer pluginsLock.Unlock()
+		f, ok = plugins[name]
+		return
+	}()
+	if !found {
+		return nil, fmt.Errorf("no Factory registered for plugin name %q", name)
+	}
+	return factory(raw)
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -50,9 +50,11 @@ type InitialContext interface {
 	// Register the given plugin REST web service
 	RegisterWS(*restful.WebService)
 
+	// Register a records source plugin
 	RegisterSource(source string) chan<- interface{}
 
-	// Return a signal chan that closes when the server enters shutdown mode.
+	// Return a signal chan that closes when the server enters shutdown mode. Plugins
+	// can react to this by performing cleanup operations before the server terminates.
 	Done() <-chan struct{}
 }
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -50,6 +50,8 @@ type InitialContext interface {
 	// Register the given plugin REST web service
 	RegisterWS(*restful.WebService)
 
+	RegisterSource(source string) chan<- interface{}
+
 	// Return a signal chan that closes when the server enters shutdown mode.
 	Done() <-chan struct{}
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/emicklei/go-restful"
-	"github.com/mesosphere/mesos-dns/resolver"
+	"github.com/mesosphere/mesos-dns/records"
 )
 
 // A plugin has a single use lifecycle: once started, it may be stopped. once stopped,
@@ -16,7 +16,7 @@ type Plugin interface {
 	// Pre-server-startup actions such as Filter or resolver.Reloader registration must
 	// be completed before this func returns. This func is not expected to block for long
 	// and should return relatively quickly.
-	Start(Context)
+	Start(Context) <-chan error
 	// Stops any running background tasks for the plugin, should return immediately.
 	Stop()
 	// Returns a signal chan that's closed once the plugin has terminated.
@@ -26,9 +26,12 @@ type Plugin interface {
 // Build a new instance of a Plugin given some JSON configuration data.
 type Factory func(json.RawMessage) (Plugin, error)
 
+// same spec as in resolver
+type Reloader func(*records.RecordGenerator) *records.RecordGenerator
+
 // Plugins use this interface to communicate with the underlying DNS resolver.
 type Resolver interface {
-	OnReload(r resolver.Reloader)
+	OnReload(r Reloader)
 }
 
 type Context interface {

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -16,7 +16,7 @@ type Plugin interface {
 	// Pre-server-startup actions such as Filter or resolver.Reloader registration must
 	// be completed before this func returns. This func is not expected to block for long
 	// and should return relatively quickly.
-	Start(Context) <-chan error
+	Start(InitialContext) <-chan error
 	// Stops any running background tasks for the plugin, should return immediately.
 	Stop()
 	// Returns a signal chan that's closed once the plugin has terminated.
@@ -34,7 +34,11 @@ type Resolver interface {
 	OnReload(r Reloader)
 }
 
-type Context interface {
+type InitialContext interface {
+
+	// Return a copy of the global configuration
+	Config() *records.Config
+
 	// Return a pointer to the mesos-dns Resolver.
 	Resolver() Resolver
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -31,7 +31,8 @@ type Reloader func(*records.RecordGenerator) *records.RecordGenerator
 
 // Plugins use this interface to communicate with the underlying DNS resolver.
 type Resolver interface {
-	OnReload(r Reloader)
+	OnPreload(r Reloader)
+	OnPostload(r Reloader)
 }
 
 type InitialContext interface {

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -13,7 +13,7 @@ import (
 // it may not be restarted.
 type Plugin interface {
 	// Performs initialization and starts any requisite background tasks for the plugin.
-	// Pre-server-startup actions such as Filter or resolver.Reloader registration must
+	// Pre-server-startup actions such as Filter or RecordLoader registration must
 	// be completed before this func returns. This func is not expected to block for long
 	// and should return relatively quickly.
 	Start(InitialContext) <-chan error
@@ -27,12 +27,12 @@ type Plugin interface {
 type Factory func(json.RawMessage) (Plugin, error)
 
 // same spec as in resolver
-type Reloader func(*records.RecordGenerator) *records.RecordGenerator
+type RecordLoader func(*records.RecordGenerator) *records.RecordGenerator
 
 // Plugins use this interface to communicate with the underlying DNS resolver.
-type Resolver interface {
-	OnPreload(r Reloader)
-	OnPostload(r Reloader)
+type RecordEvents interface {
+	OnPreload(r RecordLoader)
+	OnPostload(r RecordLoader)
 }
 
 type InitialContext interface {
@@ -40,8 +40,8 @@ type InitialContext interface {
 	// Return a copy of the global configuration
 	Config() *records.Config
 
-	// Return a pointer to the mesos-dns Resolver.
-	Resolver() Resolver
+	// Return a reference to an object that generates record loading events
+	Events() RecordEvents
 
 	// Adds a new filter handle some kind of pre- or post-processing of
 	// DNS requests and/or responses.

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -16,13 +16,13 @@ type FakePluginConfig struct {
 
 type fakePlugin struct {
 	FakePluginConfig
-	startFunc func(Context) <-chan error
+	startFunc func(InitialContext) <-chan error
 	stopFunc  func()
 	done      chan struct{}
 	doneOnce  sync.Once
 }
 
-func (p *fakePlugin) Start(ctx Context) (errCh <-chan error) {
+func (p *fakePlugin) Start(ctx InitialContext) (errCh <-chan error) {
 	if p.startFunc != nil {
 		errCh = p.startFunc(ctx)
 	}
@@ -54,7 +54,7 @@ func TestPluginConfig(t *testing.T) {
 		return &fakePlugin{
 			FakePluginConfig: c,
 			done:             make(chan struct{}),
-			startFunc: func(ctx Context) <-chan error {
+			startFunc: func(ctx InitialContext) <-chan error {
 				foo = c.Foo
 				return nil
 			},

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -16,16 +16,17 @@ type FakePluginConfig struct {
 
 type fakePlugin struct {
 	FakePluginConfig
-	startFunc func(Context)
+	startFunc func(Context) <-chan error
 	stopFunc  func()
 	done      chan struct{}
 	doneOnce  sync.Once
 }
 
-func (p *fakePlugin) Start(ctx Context) {
+func (p *fakePlugin) Start(ctx Context) (errCh <-chan error) {
 	if p.startFunc != nil {
-		p.startFunc(ctx)
+		errCh = p.startFunc(ctx)
 	}
+	return
 }
 
 func (p *fakePlugin) Stop() {
@@ -53,8 +54,9 @@ func TestPluginConfig(t *testing.T) {
 		return &fakePlugin{
 			FakePluginConfig: c,
 			done:             make(chan struct{}),
-			startFunc: func(ctx Context) {
+			startFunc: func(ctx Context) <-chan error {
 				foo = c.Foo
+				return nil
 			},
 		}, nil
 	}))

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -1,0 +1,86 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+)
+
+type FakePluginConfig struct {
+	Foo int `json:"foo,omitempty"`
+}
+
+type fakePlugin struct {
+	FakePluginConfig
+	startFunc func(Context)
+	stopFunc  func()
+	done      chan struct{}
+	doneOnce  sync.Once
+}
+
+func (p *fakePlugin) Start(ctx Context) {
+	if p.startFunc != nil {
+		p.startFunc(ctx)
+	}
+}
+
+func (p *fakePlugin) Stop() {
+	p.doneOnce.Do(func() {
+		close(p.done)
+		if p.stopFunc != nil {
+			p.stopFunc()
+		}
+	})
+}
+
+func (p *fakePlugin) Done() <-chan struct{} {
+	return p.done
+}
+
+func TestPluginConfig(t *testing.T) {
+	logging.SetupLogs()
+
+	foo := 0
+	Register("fake", Factory(func(raw json.RawMessage) (Plugin, error) {
+		var c FakePluginConfig
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal FakePluginConfig: %v", err)
+		}
+		return &fakePlugin{
+			FakePluginConfig: c,
+			done:             make(chan struct{}),
+			startFunc: func(ctx Context) {
+				foo = c.Foo
+			},
+		}, nil
+	}))
+	jsonData := `{"plugins":[{"name":"fake","settings":{"Foo":123}}]}`
+	conf := records.ParseConfig([]byte(jsonData), records.Config{Masters: []string{"bar"}, HttpOn: true, SOAMname: "d.e", SOARname: "a@b.c"})
+
+	var raw json.RawMessage
+	found := false
+	for _, pconfig := range conf.Plugins {
+		if pconfig.Name == "fake" {
+			found = true
+			raw = pconfig.Settings
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("failed to locate fake plugin configuration")
+	}
+
+	p, err := New("fake", raw)
+	if err != nil {
+		t.Fatalf("failed to create fake plugin instance: %v", err)
+	}
+
+	p.Start(nil)
+	if foo != 123 {
+		t.Fatalf("plugin not started successfully")
+	}
+}

--- a/records/config.go
+++ b/records/config.go
@@ -13,6 +13,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+type PluginConfig struct {
+	Name     string          `json:"name,omitempty"`
+	Settings json.RawMessage `json:"settings,omitempty"`
+}
+
 // Config holds mesos dns configuration
 type Config struct {
 
@@ -68,6 +73,9 @@ type Config struct {
 
 	// Enable replies for external requests
 	ExternalOn bool
+
+	// allow plugins to consume their own JSON configuration
+	Plugins []PluginConfig
 }
 
 // SetConfig instantiates a Config struct read in from config.json
@@ -110,7 +118,11 @@ func SetConfig(cjson string) (c Config) {
 	}
 	c.File = path
 
-	err = json.Unmarshal(b, &c)
+	return ParseConfig(b, c)
+}
+
+func ParseConfig(actualjson []byte, c Config) Config {
+	err := json.Unmarshal(actualjson, &c)
 	if err != nil {
 		logging.Error.Println(err)
 	}

--- a/records/config/config.go
+++ b/records/config/config.go
@@ -1,0 +1,345 @@
+package config
+
+// largely inspired by the Kubernetes pkg/kubelet/config package
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/util"
+	"github.com/mesosphere/mesos-dns/util/config"
+)
+
+// RecordConfigNotificationMode describes how changes are sent to the update channel.
+type RecordConfigNotificationMode int
+
+const (
+	// RecordConfigNotificationSnapshot delivers the full configuration as a SET whenever
+	// any change occurs.
+	RecordConfigNotificationSnapshot = iota
+	// RecordConfigNotificationSnapshotAndUpdates delivers an UPDATE message whenever records are
+	// changed, and a SET message if there are any additions or removals.
+	RecordConfigNotificationSnapshotAndUpdates
+	// RecordConfigNotificationIncremental delivers ADD, UPDATE, and REMOVE to the update channel.
+	RecordConfigNotificationIncremental
+
+	UpdatesBacklog = 50
+)
+
+// RecordConfig is a configuration mux that merges many sources of record configuration into a single
+// consistent structure, and then delivers incremental change notifications to listeners
+// in order.
+type RecordConfig struct {
+	records *recordStorage
+	mux     *config.Mux
+
+	// the channel of denormalized changes passed to listeners
+	updates chan records.Update
+
+	// contains the list of all configured sources
+	sourcesLock sync.Mutex
+	sources     util.StringSet
+}
+
+// New creates an object that can merge many configuration sources into a stream
+// of normalized updates to a record configuration.
+func New(mode RecordConfigNotificationMode) *RecordConfig {
+	updates := make(chan records.Update, UpdatesBacklog)
+	storage := newRecordStorage(updates, mode)
+	recordConfig := &RecordConfig{
+		records: storage,
+		mux:     config.NewMux(storage),
+		updates: updates,
+		sources: util.StringSet{},
+	}
+	return recordConfig
+}
+
+// Channel creates or returns a config source channel.  The channel
+// only accepts records Updates
+func (c *RecordConfig) Channel(source string) chan<- interface{} {
+	c.sourcesLock.Lock()
+	defer c.sourcesLock.Unlock()
+	c.sources.Insert(source)
+	return c.mux.Channel(source)
+}
+
+// SeenAllSources returns true if this config has received a SET
+// message from all configured sources, false otherwise.
+func (c *RecordConfig) SeenAllSources() bool {
+	if c.records == nil {
+		return false
+	}
+	logging.VeryVerbose.Printf("Looking for %v, have seen %v", c.sources.List(), c.records.sourcesSeen)
+	return c.records.seenSources(c.sources.List()...)
+}
+
+// Updates returns a channel of updates to the configuration, properly denormalized.
+func (c *RecordConfig) Updates() <-chan records.Update {
+	return c.updates
+}
+
+// Sync requests the full configuration be delivered to the update channel.
+func (c *RecordConfig) Sync() {
+	c.records.Sync()
+}
+
+// recordStorage manages the current record state at any point in time and ensures updates
+// to the channel are delivered in order.  Note that this object is an in-memory source of
+// "truth" and on creation contains zero entries.  Once all previously read sources are
+// available, then this object should be considered authoritative.
+type recordStorage struct {
+	recordLock sync.RWMutex
+	// map of source name to record set
+	records map[string]*records.RecordSet
+	mode    RecordConfigNotificationMode
+
+	// ensures that updates are delivered in strict order
+	// on the updates channel
+	updateLock sync.Mutex
+	updates    chan<- records.Update
+
+	// contains the set of all sources that have sent at least one SET
+	sourcesSeenLock sync.Mutex
+	sourcesSeen     util.StringSet
+}
+
+// TODO: RecordConfigNotificationMode could be handled by a listener to the updates channel
+// in the future, especially with multiple listeners.
+// TODO: allow initialization of the current state of the store with snapshotted version.
+func newRecordStorage(updates chan<- records.Update, mode RecordConfigNotificationMode) *recordStorage {
+	return &recordStorage{
+		records:     make(map[string]*records.RecordSet),
+		mode:        mode,
+		updates:     updates,
+		sourcesSeen: util.StringSet{},
+	}
+}
+
+// Merge normalizes a set of incoming changes from different sources into a map of all RecordSets
+// and ensures that redundant changes are filtered out, and then pushes zero or more minimal
+// updates onto the update channel.  Ensures that updates are delivered in order.
+func (s *recordStorage) Merge(source string, change interface{}) error {
+	s.updateLock.Lock()
+	defer s.updateLock.Unlock()
+
+	adds, updates, deletes := s.merge(source, change)
+
+	// deliver update notifications
+	switch s.mode {
+	case RecordConfigNotificationIncremental:
+		if deletes.Records.Size() > 0 {
+			s.updates <- *deletes
+		}
+		if adds.Records.Size() > 0 {
+			s.updates <- *adds
+		}
+		if updates.Records.Size() > 0 {
+			s.updates <- *updates
+		}
+
+	case RecordConfigNotificationSnapshotAndUpdates:
+		if updates.Records.Size() > 0 {
+			s.updates <- *updates
+		}
+		if deletes.Records.Size() > 0 || adds.Records.Size() > 0 {
+			upd := s.MergedState().(*records.RecordSet)
+			s.updates <- records.Update{Records: *upd, Op: records.SET, Source: source}
+		}
+
+	case RecordConfigNotificationSnapshot:
+		if updates.Records.Size() > 0 || deletes.Records.Size() > 0 || adds.Records.Size() > 0 {
+			upd := s.MergedState().(*records.RecordSet)
+			s.updates <- records.Update{Records: *upd, Op: records.SET, Source: source}
+		}
+
+	default:
+		panic(fmt.Sprintf("unsupported RecordConfigNotificationMode: %#v", s.mode))
+	}
+
+	return nil
+}
+
+func (s *recordStorage) merge(source string, change interface{}) (adds, updates, deletes *records.Update) {
+	s.recordLock.Lock()
+	defer s.recordLock.Unlock()
+
+	adds = &records.Update{Op: records.ADD}
+	updates = &records.Update{Op: records.UPDATE}
+	deletes = &records.Update{Op: records.REMOVE}
+
+	recordSets := s.records[source]
+	if recordSets == nil {
+		recordSets = &records.RecordSet{}
+	}
+
+	update := change.(records.Update)
+	switch update.Op {
+	case records.ADD, records.UPDATE:
+		if update.Op == records.ADD {
+			logging.VeryVerbose.Printf("Adding new records from source %s : %v", source, update.Records)
+		} else {
+			logging.VeryVerbose.Printf("Updating records from source %s : %v", source, update.Records)
+		}
+
+		//TODO(jdef) reinstitute this at some point
+		//filtered := filterInvalidRecords(update.Records, source)
+
+		for name, ref := range update.Records.As {
+			if existing, found := recordSets.As.Get(name); found {
+				if !reflect.DeepEqual(existing, ref) {
+					// this is an update
+					existing = ref
+					update.Records.As = update.Records.As.Put(name, existing)
+					continue
+				}
+				// this is a no-op
+				continue
+			}
+			recordSets.As = recordSets.As.Put(name, ref)
+			adds.Records.As = adds.Records.As.Put(name, ref)
+		}
+		for name, ref := range update.Records.SRVs {
+			if existing, found := recordSets.SRVs.Get(name); found {
+				if !reflect.DeepEqual(existing, ref) {
+					// this is an update
+					existing = ref
+					update.Records.SRVs = update.Records.SRVs.Put(name, existing)
+					continue
+				}
+				// this is a no-op
+				continue
+			}
+			recordSets.SRVs = recordSets.SRVs.Put(name, ref)
+			adds.Records.SRVs = adds.Records.SRVs.Put(name, ref)
+		}
+
+	case records.REMOVE:
+		logging.VeryVerbose.Printf("Removing records %v", update)
+		for name, _ := range update.Records.As {
+			if existing, found := recordSets.As.Get(name); found {
+				// this is a delete
+				recordSets.As.Delete(name)
+				deletes.Records.As = deletes.Records.As.Put(name, existing)
+				continue
+			}
+			// this is a no-op
+		}
+		for name, _ := range update.Records.SRVs {
+			if existing, found := recordSets.SRVs.Get(name); found {
+				// this is a delete
+				recordSets.SRVs.Delete(name)
+				deletes.Records.SRVs = deletes.Records.SRVs.Put(name, existing)
+				continue
+			}
+			// this is a no-op
+		}
+
+	case records.SET:
+		logging.VeryVerbose.Printf("Setting records for source %s : %v", source, update)
+		s.markSourceSet(source)
+
+		// Clear the old entries
+		oldAs := recordSets.As
+		recordSets.As = nil
+
+		//TODO(jdef) reinstitute this at some point
+		//filtered := filterInvalidRecords(update.RecordSets, source)
+
+		for name, ref := range update.Records.As {
+			if existing, found := oldAs.Get(name); found {
+				recordSets.As.Put(name, existing)
+				if !reflect.DeepEqual(existing, ref) {
+					// this is an update
+					existing = ref
+					updates.Records.As = updates.Records.As.Put(name, existing)
+					continue
+				}
+				// this is a no-op
+				continue
+			}
+			recordSets.As = recordSets.As.Put(name, ref)
+			adds.Records.As = adds.Records.As.Put(name, ref)
+		}
+		for name, existing := range oldAs {
+			if _, found := recordSets.As.Get(name); !found {
+				// this is a delete
+				deletes.Records.As = deletes.Records.As.Put(name, existing)
+			}
+		}
+
+		// Clear the old entries
+		oldSRVs := recordSets.SRVs
+		recordSets.SRVs = nil
+
+		for name, ref := range update.Records.SRVs {
+			if existing, found := oldSRVs.Get(name); found {
+				recordSets.SRVs.Put(name, existing)
+				if !reflect.DeepEqual(existing, ref) {
+					// this is an update
+					existing = ref
+					updates.Records.SRVs = updates.Records.SRVs.Put(name, existing)
+					continue
+				}
+				// this is a no-op
+				continue
+			}
+			recordSets.SRVs = recordSets.SRVs.Put(name, ref)
+			adds.Records.SRVs = adds.Records.SRVs.Put(name, ref)
+		}
+		for name, existing := range oldSRVs {
+			if _, found := recordSets.SRVs.Get(name); !found {
+				// this is a delete
+				deletes.Records.SRVs = deletes.Records.SRVs.Put(name, existing)
+			}
+		}
+
+	default:
+		logging.Error.Printf("Received invalid update type: %v", update)
+
+	}
+
+	s.records[source] = recordSets
+	return adds, updates, deletes
+}
+
+func (s *recordStorage) markSourceSet(source string) {
+	s.sourcesSeenLock.Lock()
+	defer s.sourcesSeenLock.Unlock()
+	s.sourcesSeen.Insert(source)
+}
+
+func (s *recordStorage) seenSources(sources ...string) bool {
+	s.sourcesSeenLock.Lock()
+	defer s.sourcesSeenLock.Unlock()
+	return s.sourcesSeen.HasAll(sources...)
+}
+
+// Sync sends a copy of the current state through the update channel.
+func (s *recordStorage) Sync() {
+	s.updateLock.Lock()
+	defer s.updateLock.Unlock()
+	upd := s.MergedState().(*records.RecordSet)
+	s.updates <- records.Update{Records: *upd, Op: records.SET, Source: records.AllSource}
+}
+
+// Object implements config.Accessor
+func (s *recordStorage) MergedState() interface{} {
+	s.recordLock.RLock()
+	defer s.recordLock.RUnlock()
+	recordSet := &records.RecordSet{}
+	for _, sourceRecords := range s.records {
+		for name, recordRef := range sourceRecords.As {
+			ans := recordRef.Clone()
+			recordSet.As = recordSet.As.Put(name, ans)
+		}
+		for name, recordRef := range sourceRecords.SRVs {
+			ans := recordRef.Clone()
+			recordSet.SRVs = recordSet.SRVs.Put(name, ans)
+		}
+	}
+	return recordSet
+}

--- a/records/config/config_test.go
+++ b/records/config/config_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	logging.VerboseFlag = false
+	logging.SetupLogs()
+}
+
+func TestMergeAddUpdate(t *testing.T) {
+	assert := assert.New(t)
+	sourceRecords := records.RecordSet{}
+	adds := &records.Update{}
+	updates := &records.Update{}
+
+	event := &records.Update{
+		Records: records.RecordSet{
+			As:   records.RRS{"james": records.Answer{"foo", "bar"}},
+			SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	mergeAddUpdate(&sourceRecords, event, adds, updates)
+	assert.True(reflect.DeepEqual(sourceRecords, event.Records), "expected %v instead of %v", event.Records, sourceRecords)
+	assert.True(reflect.DeepEqual(adds.Records, event.Records))
+	assert.True(reflect.DeepEqual(updates.Records, records.RecordSet{}))
+
+	// add a new record to source record set that's non-empty
+	event2 := &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{"bill": records.Answer{"june", "july"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	expected := &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{
+				"james": records.Answer{"foo", "bar"},
+				"bill":  records.Answer{"june", "july"},
+			},
+			SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	adds = &records.Update{}
+	updates = &records.Update{}
+	mergeAddUpdate(&sourceRecords, event2, adds, updates)
+	assert.True(reflect.DeepEqual(sourceRecords, expected.Records), "expected %v instead of %v", expected.Records, sourceRecords)
+	assert.True(reflect.DeepEqual(adds.Records, event2.Records))
+	assert.True(reflect.DeepEqual(updates.Records, records.RecordSet{}))
+
+	// update an existing record
+	event3 := &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{"bill": records.Answer{"june", "october"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	expected = &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{
+				"james": records.Answer{"foo", "bar"},
+				"bill":  records.Answer{"june", "october"},
+			},
+			SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	adds = &records.Update{}
+	updates = &records.Update{}
+	mergeAddUpdate(&sourceRecords, event3, adds, updates)
+	assert.True(reflect.DeepEqual(sourceRecords, expected.Records), "expected %v instead of %v", expected.Records, sourceRecords)
+	assert.True(reflect.DeepEqual(adds.Records, records.RecordSet{}))
+	assert.True(reflect.DeepEqual(updates.Records, event3.Records))
+}
+
+func TestMergeRemove(t *testing.T) {
+	assert := assert.New(t)
+	sourceRecords := records.RecordSet{
+		As:   records.RRS{"james": records.Answer{"foo", "bar"}},
+		SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+	}
+	deletes := &records.Update{}
+
+	event := &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{"james": records.Answer{"foo", "bar"}},
+		},
+		Op:     records.REMOVE,
+		Source: records.MasterSource,
+	}
+	mergeRemove(&sourceRecords, event, deletes)
+
+	expected := &records.Update{
+		Records: records.RecordSet{
+			As:   records.RRS{},
+			SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+		},
+		Op:     records.REMOVE,
+		Source: records.MasterSource,
+	}
+	assert.True(reflect.DeepEqual(sourceRecords, expected.Records), "expected %v instead of %v", expected.Records, sourceRecords)
+	assert.True(reflect.DeepEqual(deletes.Records, event.Records), "expected %v instead of %v", event.Records, deletes.Records)
+}
+
+func TestMergeSet(t *testing.T) {
+	assert := assert.New(t)
+	adds := &records.Update{}
+	updates := &records.Update{}
+	deletes := &records.Update{}
+
+	sourceRecords := records.RecordSet{
+		As: records.RRS{
+			"james": records.Answer{"zebra", "bar"},
+			"kat":   records.Answer{"jen", "carrie"},
+		},
+		SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+	}
+	event := &records.Update{
+		Records: records.RecordSet{
+			As: records.RRS{
+				"james": records.Answer{"foo", "bar"},   // updated
+				"joe":   records.Answer{"nick", "chad"}, // added
+				// kat was deleted
+			},
+			SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+		},
+		Op:     records.ADD,
+		Source: records.MasterSource,
+	}
+	mergeSet(&sourceRecords, event, adds, updates, deletes)
+
+	expected := records.RecordSet{
+		As: records.RRS{
+			"james": records.Answer{"foo", "bar"},
+			"joe":   records.Answer{"nick", "chad"},
+		},
+		SRVs: records.RRS{"anna": records.Answer{"cat", "dog"}},
+	}
+	assert.True(reflect.DeepEqual(sourceRecords, expected), "expected %v instead of %v", expected, sourceRecords)
+	assert.True(reflect.DeepEqual(adds.Records, records.RecordSet{
+		As: records.RRS{"joe": records.Answer{"nick", "chad"}},
+	}))
+	assert.True(reflect.DeepEqual(updates.Records, records.RecordSet{
+		As: records.RRS{"james": records.Answer{"foo", "bar"}},
+	}))
+	assert.True(reflect.DeepEqual(deletes.Records, records.RecordSet{
+		As: records.RRS{"kat": records.Answer{"jen", "carrie"}},
+	}))
+}

--- a/records/config/master.go
+++ b/records/config/master.go
@@ -1,0 +1,239 @@
+package config
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/mesos/mesos-go/detector"
+	_ "github.com/mesos/mesos-go/detector/zoo"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/util"
+)
+
+const (
+	zkInitialDetectionTimeout = 30 * time.Second
+)
+
+type RecordLoader func(*records.RecordGenerator) *records.RecordGenerator
+
+type MasterSource struct {
+	config     records.Config
+	errHandler func(string, error)
+
+	// always points to the leading master
+	leader     string
+	leaderLock sync.Mutex
+
+	// preLoaders are invoked at the beginning of the Reload cycle, just prior to state generation
+	preLoaders []RecordLoader
+
+	// postLoaders are invoked at the end of the Reload cycle, after state generation
+	postLoaders []RecordLoader
+
+	startZKdetection func(zkurl string, leaderChanged func(string)) error
+}
+
+// mesos master config source
+func NewSourceMaster(config records.Config, eh func(string, error), updates chan<- interface{}) *MasterSource {
+	m := &MasterSource{
+		config:           config,
+		errHandler:       eh,
+		startZKdetection: startDefaultZKdetector,
+	}
+	go m.run(updates)
+	return m
+}
+
+// execute a RecordLoader func at Reload time. this func should only be invoked during
+// bootstrapping (before processing begins) since this is not "thread-safe".
+func (c *MasterSource) OnPreload(r RecordLoader) {
+	if r != nil {
+		c.preLoaders = append(c.preLoaders, r)
+	}
+}
+
+// execute a RecordLoader func at Reload time. this func should only be invoked during
+// bootstrapping (before processing begins) since this is not "thread-safe".
+func (c *MasterSource) OnPostload(r RecordLoader) {
+	if r != nil {
+		c.postLoaders = append(c.postLoaders, r)
+	}
+}
+
+func (c *MasterSource) getLeader() string {
+	c.leaderLock.Lock()
+	defer c.leaderLock.Unlock()
+	return c.leader
+}
+
+// launch Zookeeper listener
+func (c *MasterSource) beginLeaderWatch() (newLeader <-chan struct{}, zkErr <-chan error) {
+	if c.config.Zk != "" {
+		newLeader, zkErr = c.launchZK(zkInitialDetectionTimeout)
+	} else {
+		// uniform behavior when new leader from masters field
+		leader := make(chan struct{}, 1)
+		leader <- struct{}{}
+		newLeader = leader
+	}
+	return
+}
+
+// periodically reload DNS records, either because the reload timer expired or else
+// because a caller invoked the tryReload func returned by this func.
+func (c *MasterSource) launchReloader(updates chan<- interface{}) (tryReload func()) {
+	// generate reload signal; up to 1 reload pending at any time
+	reloadSignal := make(chan struct{}, 1)
+	tryReload = func() {
+		// non-blocking, attempt to queue a reload
+		select {
+		case reloadSignal <- struct{}{}:
+		default:
+		}
+	}
+
+	// periodic loading of DNS state (pull from Master)
+	go func() {
+		defer util.HandleCrash()
+		reloadTimeout := time.Second * time.Duration(c.config.RefreshSeconds)
+		reloadTimer := time.AfterFunc(reloadTimeout, tryReload)
+		for _ = range reloadSignal {
+			c.reload(updates)
+			logging.PrintCurLog()
+			reloadTimer.Reset(reloadTimeout)
+		}
+	}()
+	return
+}
+
+func (c *MasterSource) run(updates chan<- interface{}) {
+	newLeader, zkErr := c.beginLeaderWatch()
+	tryReload := c.launchReloader(updates)
+
+	// infinite loop until there is fatal error
+	for {
+		select {
+		case <-newLeader:
+			tryReload()
+		case err := <-zkErr:
+			c.errHandler("ZK watcher", err)
+		}
+	}
+}
+
+// launches Zookeeper detector, returns immediately two chans: the first fires an empty
+// struct whenever there's a new (non-nil) mesos leader, the second if there's an unrecoverable
+// error in the master detector.
+func (c *MasterSource) launchZK(initialDetectionTimeout time.Duration) (<-chan struct{}, <-chan error) {
+	var startedOnce sync.Once
+	startedCh := make(chan struct{})
+	errCh := make(chan error, 1)
+	leaderCh := make(chan struct{}, 1) // the first write never blocks
+
+	listenerFunc := func(newLeader string) {
+		defer func() {
+			if newLeader != "" {
+				leaderCh <- struct{}{}
+				startedOnce.Do(func() { close(startedCh) })
+			}
+		}()
+		c.leaderLock.Lock()
+		defer c.leaderLock.Unlock()
+		c.leader = newLeader
+	}
+	go func() {
+		defer util.HandleCrash()
+
+		err := c.startZKdetection(c.config.Zk, listenerFunc)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		logging.VeryVerbose.Println("Warning: waiting for initial information from Zookeper.")
+		select {
+		case <-startedCh:
+			logging.VeryVerbose.Println("Info: got initial information from Zookeper.")
+		case <-time.After(initialDetectionTimeout):
+			errCh <- fmt.Errorf("timed out waiting for initial ZK detection, exiting")
+		}
+	}()
+	return leaderCh, errCh
+}
+
+// Start a Zookeeper listener to track leading master, invokes callback function when
+// master changes are reported.
+func startDefaultZKdetector(zkurl string, leaderChanged func(string)) error {
+
+	// start listener
+	logging.Verbose.Println("Starting master detector for ZK ", zkurl)
+	md, err := detector.New(zkurl)
+	if err != nil {
+		return fmt.Errorf("failed to create master detector: %v", err)
+	}
+
+	// and listen for master changes
+	if err := md.Detect(detector.OnMasterChanged(func(info *mesos.MasterInfo) {
+		leader := ""
+		if leaderChanged != nil {
+			defer func() {
+				leaderChanged(leader)
+			}()
+		}
+		logging.VeryVerbose.Println("Updated Zookeeper info: ", info)
+		if info == nil {
+			logging.Error.Println("No leader available in Zookeeper.")
+		} else {
+			if host := info.GetHostname(); host != "" {
+				leader = host
+			} else {
+				// unpack IPv4
+				octets := make([]byte, 4, 4)
+				binary.BigEndian.PutUint32(octets, info.GetIp())
+				ipv4 := net.IP(octets)
+				leader = ipv4.String()
+			}
+			leader = fmt.Sprintf("%s:%d", leader, info.GetPort())
+			logging.Verbose.Println("new master in Zookeeper ", leader)
+		}
+	})); err != nil {
+		return fmt.Errorf("failed to initialize master detector: %v", err)
+	}
+	return nil
+}
+
+// triggers a new refresh from mesos master
+func (c *MasterSource) reload(updates chan<- interface{}) {
+	t := records.RecordGenerator{}
+	t.TaskRecordGeneratorFn = t.BuildTaskRecords
+
+	// pre-ParseState phase, preloader plugins can wrap around, or otherwise customize,
+	// a RecordGenerator.TaskRecordGeneratorFn. useful if plugins want to create additional
+	// records based on, for example, task labels.
+	state := &t
+	for _, g := range c.preLoaders {
+		state = g(state)
+	}
+
+	if err := state.ParseState(c.getLeader(), c.config); err != nil {
+		logging.VeryVerbose.Printf("Warning: master not found; keeping old DNS state: %v", err)
+		return
+	}
+
+	// post-ParseState phase, postloader plugins can modify generated records.
+	//TODO(jdef) is this really useful?!
+	for _, r := range c.postLoaders {
+		state = r(state)
+	}
+
+	updates <- records.Update{
+		Records: state.RecordSet,
+		Op:      records.SET,
+		Source:  records.MasterSource,
+	}
+}

--- a/records/config/master_test.go
+++ b/records/config/master_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mesosphere/mesos-dns/util"
+)
+
+func TestLaunchZK(t *testing.T) {
+	var closeOnce sync.Once
+	ch := make(chan struct{})
+	closer := func() { closeOnce.Do(func() { close(ch) }) }
+	res := &MasterSource{
+		startZKdetection: func(zkurl string, leaderChanged func(string)) error {
+			go func() {
+				defer closer()
+				leaderChanged("")
+				leaderChanged("")
+				leaderChanged("a")
+				leaderChanged("")
+				leaderChanged("")
+				leaderChanged("b")
+				leaderChanged("")
+				leaderChanged("")
+				leaderChanged("c")
+			}()
+			return nil
+		},
+	}
+	leaderSig, errCh := res.launchZK(1 * time.Second)
+	util.OnError(ch, errCh, func(err error) { t.Fatalf("unexpected error: %v", err) })
+	getLeader := func() string {
+		res.leaderLock.Lock()
+		defer res.leaderLock.Unlock()
+		return res.leader
+	}
+	for i := 0; i < 3; i++ {
+		select {
+		case <-leaderSig:
+			t.Logf("new leader %d: %s", i, getLeader())
+		case <-time.After(1 * time.Second):
+			t.Fatalf("timed out waiting for new leader")
+		}
+	}
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for detector death")
+	}
+	// there should be nothing left in the leader signal chan
+	select {
+	case <-leaderSig:
+		t.Fatalf("unexpected new leader")
+	case <-time.After(200 * time.Millisecond):
+		// expected
+	}
+}

--- a/records/config/master_test.go
+++ b/records/config/master_test.go
@@ -5,8 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/util"
 )
+
+func init() {
+	logging.VerboseFlag = false
+	logging.SetupLogs()
+}
 
 func TestLaunchZK(t *testing.T) {
 	var closeOnce sync.Once

--- a/records/generator.go
+++ b/records/generator.go
@@ -17,18 +17,12 @@ import (
 	"github.com/mesosphere/mesos-dns/records/labels"
 )
 
-// Map host/service name to DNS answer
-// REFACTOR - when discoveryinfo is integrated
-// Will likely become map[string][]discoveryinfo
-type rrs map[string][]string
-
 type TaskRecordGeneratorFn func(task *Task, frameworkName, slaveHost, domain string)
 
 // Mesos-DNS state
 // Refactor when discovery id is available
 type RecordGenerator struct {
-	As     rrs
-	SRVs   rrs
+	RecordSet
 	Slaves map[string]string
 	TaskRecordGeneratorFn
 }
@@ -238,8 +232,8 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, ns string,
 		rg.Slaves[slave.Id] = sanitizedSlaveAddress(slave.Hostname)
 	}
 
-	rg.SRVs = make(rrs)
-	rg.As = make(rrs)
+	rg.SRVs = make(RRS)
+	rg.As = make(RRS)
 
 	trecGenerator := rg.TaskRecordGeneratorFn
 	if trecGenerator == nil {

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -186,7 +186,7 @@ func TestInsertState(t *testing.T) {
 // ensure we only generate one A record for each host
 func TestNTasks(t *testing.T) {
 	rg := RecordGenerator{}
-	rg.As = make(rrs)
+	rg.As = make(RRS)
 
 	rg.insertRR("blah.mesos", "10.0.0.1", "A")
 	rg.insertRR("blah.mesos", "10.0.0.1", "A")

--- a/records/types.go
+++ b/records/types.go
@@ -1,0 +1,84 @@
+package records
+
+type Answer []string
+
+// REFACTOR - when discoveryinfo is integrated
+func (a Answer) Clone() Answer {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return Answer(b)
+}
+
+// Map host/service name to DNS answer
+type RRS map[string]Answer
+
+// Mesos-DNS state
+// Refactor when discovery id is available
+type RecordSet struct {
+	As   RRS
+	SRVs RRS
+}
+
+func (rrs RRS) Put(name string, ans Answer) RRS {
+	if rrs == nil {
+		rrs = make(RRS)
+	}
+	rrs[name] = ans
+	return rrs
+}
+
+func (rrs RRS) Get(name string) (v Answer, found bool) {
+	if rrs != nil {
+		v, found = rrs[name]
+	}
+	return
+}
+
+func (rrs RRS) Delete(name string) {
+	if rrs == nil {
+		return
+	}
+	delete(rrs, name)
+}
+
+func (rs *RecordSet) Size() int {
+	if rs == nil {
+		return 0
+	}
+	return len(rs.As) + len(rs.SRVs)
+}
+
+// Operation defines what changes will be made on a pod configuration.
+type Operation int
+
+const (
+	// This is the current pod configuration
+	SET Operation = iota
+	// RecordSets with the given ids are new to this source
+	ADD
+	// RecordSets with the given ids have been removed from this source
+	REMOVE
+	// RecordSets with the given ids have been updated in this source
+	UPDATE
+
+	// These constants identify the sources of records
+
+	// Standard record updates generated from Mesos Master tasks
+	MasterSource = "master"
+	// Updates from all sources
+	AllSource = "*"
+)
+
+// Update defines an operation sent on the channel. You can add or remove single services by
+// sending an array of size one and Op == ADD|REMOVE (with REMOVE, only the ID is required).
+// For setting the state of the system to a given state for this source configuration, set
+// Records as desired and Op to SET, which will reset the system state to that specified in this
+// operation for this source channel. To remove all pods, set Records to empty object and Op to SET.
+type Update struct {
+	Records RecordSet
+	Op      Operation
+	Source  string
+}

--- a/records/types.go
+++ b/records/types.go
@@ -44,6 +44,11 @@ func (rrs RRS) Delete(name string) {
 	delete(rrs, name)
 }
 
+func Put(rrs *RRS, name string, ans Answer) {
+	x := (*rrs).Put(name, ans)
+	*rrs = x
+}
+
 func (rs *RecordSet) Size() int {
 	if rs == nil {
 		return 0

--- a/resolver/dns_plugin.go
+++ b/resolver/dns_plugin.go
@@ -1,0 +1,438 @@
+// package resolver contains functions to handle resolving .mesos
+// domains
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/plugins"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/util"
+	"github.com/miekg/dns"
+)
+
+const (
+	recurseCnt = 3
+)
+
+type dnsRecordsInterface interface {
+	records() *records.RecordSet
+	getSOASerial() uint32
+}
+
+type DNSPlugin struct {
+	dnsi         dnsRecordsInterface
+	config       *records.Config
+	done         chan struct{}
+	applyFilters func(dns.Handler) dns.Handler
+
+	// pluggable external DNS resolution, mainly for unit testing
+	extResolver func(r *dns.Msg, nameserver string, proto string, cnt int) (*dns.Msg, error)
+}
+
+func NewDNSPlugin(dnsi dnsRecordsInterface, applyFilters func(dns.Handler) dns.Handler) *DNSPlugin {
+	plugin := &DNSPlugin{
+		dnsi:         dnsi,
+		done:         make(chan struct{}),
+		applyFilters: applyFilters,
+	}
+	plugin.extResolver = plugin.defaultExtResolver
+	return plugin
+}
+
+// starts an http server for mesos-dns queries, returns immediately
+func (p *DNSPlugin) Start(ctx plugins.InitialContext) <-chan error {
+	p.config = ctx.Config()
+
+	// Handers for Mesos requests
+	dns.Handle(p.config.Domain+".", panicRecover(p.applyFilters(dns.HandlerFunc(p.handleMesos))))
+	// Handler for nonMesos requests
+	dns.Handle(".", panicRecover(p.applyFilters(dns.HandlerFunc(p.handleNonMesos))))
+
+	var doneOnce sync.Once
+	closeDone := func() { doneOnce.Do(func() { close(p.done) }) }
+
+	errCh := make(chan error, 2)
+	_, e1 := p.serveDNS("tcp")
+	go func() {
+		defer closeDone()
+		errCh <- <-e1
+	}()
+	_, e2 := p.serveDNS("udp")
+	go func() {
+		defer closeDone()
+		errCh <- <-e2
+	}()
+	return errCh
+}
+
+func (p *DNSPlugin) Stop() {
+	//TODO(jdef)
+}
+
+func (p *DNSPlugin) Done() <-chan struct{} {
+	return p.done
+}
+
+// starts a DNS server for net protocol (tcp/udp), returns immediately.
+// the returned signal chan is closed upon the server successfully entering the listening phase.
+// if the server aborts then an error is sent on the error chan.
+func (p *DNSPlugin) serveDNS(net string) (<-chan struct{}, <-chan error) {
+	defer util.HandleCrash()
+
+	ch := make(chan struct{})
+	server := &dns.Server{
+		Addr:              p.config.Listener + ":" + strconv.Itoa(p.config.Port),
+		Net:               net,
+		TsigSecret:        nil,
+		NotifyStartedFunc: func() { close(ch) },
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		err := server.ListenAndServe()
+		if err != nil {
+			errCh <- fmt.Errorf("Failed to setup %q server: %v", net, err)
+		} else {
+			logging.Error.Printf("Not listening/serving any more requests.")
+		}
+	}()
+	return ch, errCh
+}
+
+// defaultExtResolver queries other nameserver, potentially recurses; callers should probably be invoking extResolver
+// instead since that's the pluggable entrypoint into external resolution.
+func (p *DNSPlugin) defaultExtResolver(r *dns.Msg, nameserver string, proto string, cnt int) (*dns.Msg, error) {
+	var in *dns.Msg
+	var err error
+
+	c := new(dns.Client)
+	c.Net = proto
+
+	var t time.Duration = 5 * 1e9
+	if p.config.Timeout != 0 {
+		t = time.Duration(int64(p.config.Timeout * 1e9))
+	}
+
+	c.DialTimeout = t
+	c.ReadTimeout = t
+	c.WriteTimeout = t
+
+	in, _, err = c.Exchange(r, nameserver)
+	if err != nil {
+		return in, err
+	}
+
+	// recurse
+	if (in != nil) && (len(in.Answer) == 0) && (!in.MsgHdr.Authoritative) && (len(in.Ns) > 0) && (err != nil) {
+
+		if cnt == recurseCnt {
+			logging.CurLog.NonMesosRecursed.Inc()
+		}
+
+		if cnt > 0 {
+			if soa, ok := (in.Ns[0]).(*dns.SOA); ok {
+				return p.defaultExtResolver(r, soa.Ns+":53", proto, cnt-1)
+			}
+		}
+
+	}
+
+	return in, err
+}
+
+// formatSRV returns the SRV resource record for target
+func (p *DNSPlugin) formatSRV(name string, target string) (*dns.SRV, error) {
+	ttl := uint32(p.config.TTL)
+
+	h, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return nil, errors.New("invalid target")
+	}
+	iport, _ := strconv.Atoi(port)
+
+	return &dns.SRV{
+		Hdr: dns.RR_Header{
+			Name:   name,
+			Rrtype: dns.TypeSRV,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Priority: 0,
+		Weight:   0,
+		Port:     uint16(iport),
+		Target:   h,
+	}, nil
+}
+
+// returns the A resource record for target
+// assumes target is a well formed IPv4 address
+func (p *DNSPlugin) formatA(dom string, target string) (*dns.A, error) {
+	ttl := uint32(p.config.TTL)
+
+	a := net.ParseIP(target)
+	if a == nil {
+		return nil, errors.New("invalid target")
+	}
+
+	return &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   dom,
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    ttl},
+		A: a.To4(),
+	}, nil
+}
+
+// formatSOA returns the SOA resource record for the mesos domain
+func (p *DNSPlugin) formatSOA(dom string) (*dns.SOA, error) {
+	ttl := uint32(p.config.TTL)
+
+	return &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   dom,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Ns:      p.config.SOARname,
+		Mbox:    p.config.SOAMname,
+		Serial:  p.dnsi.getSOASerial(),
+		Refresh: p.config.SOARefresh,
+		Retry:   p.config.SOARetry,
+		Expire:  p.config.SOAExpire,
+		Minttl:  ttl,
+	}, nil
+}
+
+// formatNS returns the NS  record for the mesos domain
+func (p *DNSPlugin) formatNS(dom string) (*dns.NS, error) {
+	ttl := uint32(p.config.TTL)
+
+	return &dns.NS{
+		Hdr: dns.RR_Header{
+			Name:   dom,
+			Rrtype: dns.TypeNS,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Ns: p.config.SOAMname,
+	}, nil
+}
+
+// reorders answers for very basic load balancing
+func shuffleAnswers(answers []dns.RR) []dns.RR {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	n := len(answers)
+	for i := 0; i < n; i++ {
+		r := i + rand.Intn(n-i)
+		answers[r], answers[i] = answers[i], answers[r]
+	}
+
+	return answers
+}
+
+// makes non-mesos queries to external nameserver
+func (p *DNSPlugin) handleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
+	var err error
+	var m *dns.Msg
+
+	// tracing info
+	logging.CurLog.NonMesosRequests.Inc()
+
+	// If external request are disabled
+	if !p.config.ExternalOn {
+		m = new(dns.Msg)
+		// set refused
+		m.SetRcode(r, 5)
+	} else {
+
+		proto := "udp"
+		if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+			proto = "tcp"
+		}
+
+		for _, resolver := range p.config.Resolvers {
+			nameserver := resolver + ":53"
+			m, err = p.extResolver(r, nameserver, proto, recurseCnt)
+			if err == nil {
+				break
+			}
+		}
+	}
+
+	// extResolver returns nil Msg sometimes cause of perf
+	if m == nil {
+		m = new(dns.Msg)
+		m.SetRcode(r, 2)
+		err = errors.New("nil msg")
+	}
+	if err != nil {
+		logging.Error.Println(r.Question[0].Name)
+		logging.Error.Println(err)
+		logging.CurLog.NonMesosFailed.Inc()
+	} else {
+		// nxdomain
+		if len(m.Answer) == 0 {
+			logging.CurLog.NonMesosNXDomain.Inc()
+		} else {
+			logging.CurLog.NonMesosSuccess.Inc()
+		}
+	}
+
+	err = w.WriteMsg(m)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+}
+
+// handleMesos is a resolver request handler that responds to a resource
+// question with resource answer(s)
+// it can handle {A, SRV, ANY}
+func (p *DNSPlugin) handleMesos(w dns.ResponseWriter, r *dns.Msg) {
+	var err error
+
+	dom := strings.ToLower(cleanWild(r.Question[0].Name))
+	qType := r.Question[0].Qtype
+
+	m := new(dns.Msg)
+	m.Authoritative = true
+	m.RecursionAvailable = p.config.RecurseOn
+	m.SetReply(r)
+
+	rs := p.dnsi.records()
+
+	// SRV requests
+	if (qType == dns.TypeSRV) || (qType == dns.TypeANY) {
+		for _, srv := range rs.SRVs[dom] {
+			rr, err := p.formatSRV(r.Question[0].Name, srv)
+			if err != nil {
+				logging.Error.Println(err)
+			} else {
+				m.Answer = append(m.Answer, rr)
+				// return one corresponding A record add additional info
+				host := strings.Split(srv, ":")[0]
+				if len(rs.As[host]) != 0 {
+					rr, err := p.formatA(host, rs.As[host][0])
+					if err != nil {
+						logging.Error.Println(err)
+					} else {
+						m.Extra = append(m.Extra, rr)
+					}
+				}
+
+			}
+		}
+	}
+
+	// A requests
+	if (qType == dns.TypeA) || (qType == dns.TypeANY) {
+		for _, a := range rs.As[dom] {
+			rr, err := p.formatA(dom, a)
+			if err != nil {
+				logging.Error.Println(err)
+			} else {
+				m.Answer = append(m.Answer, rr)
+			}
+
+		}
+	}
+
+	// SOA requests
+	if (qType == dns.TypeSOA) || (qType == dns.TypeANY) {
+		rr, err := p.formatSOA(r.Question[0].Name)
+		if err != nil {
+			logging.Error.Println(err)
+		} else {
+			m.Ns = append(m.Ns, rr)
+		}
+	}
+
+	// NS requests
+	if (qType == dns.TypeNS) || (qType == dns.TypeANY) {
+		rr, err := p.formatNS(r.Question[0].Name)
+		logging.Error.Println("NS request")
+		if err != nil {
+			logging.Error.Println(err)
+		} else {
+			m.Ns = append(m.Ns, rr)
+		}
+	}
+
+	// shuffle answers
+	m.Answer = shuffleAnswers(m.Answer)
+	// tracing info
+	logging.CurLog.MesosRequests.Inc()
+
+	if err != nil {
+		logging.CurLog.MesosFailed.Inc()
+	} else if (qType == dns.TypeAAAA) && (len(rs.SRVs[dom]) > 0 || len(rs.As[dom]) > 0) {
+		// correct handling of AAAA if there are A or SRV records
+		m.Authoritative = true
+		// set NOERROR
+		m.SetRcode(r, 0)
+		// leave answer empty (NOERROR --> NODATA)
+
+	} else {
+		// no answers but not a {SOA,SRV} request
+		if len(m.Answer) == 0 && (qType != dns.TypeSOA) && (qType != dns.TypeNS) && (qType != dns.TypeSRV) {
+			// set NXDOMAIN
+			m.SetRcode(r, 3)
+
+			rr, err := p.formatSOA(r.Question[0].Name)
+			if err != nil {
+				logging.Error.Println(err)
+			} else {
+				m.Ns = append(m.Ns, rr)
+			}
+
+			logging.CurLog.MesosNXDomain.Inc()
+			logging.VeryVerbose.Println("total A rrs:\t" + strconv.Itoa(len(rs.As)))
+			logging.VeryVerbose.Println("failed looking for " + r.Question[0].String())
+		} else {
+			logging.CurLog.MesosSuccess.Inc()
+		}
+	}
+
+	err = w.WriteMsg(m)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+}
+
+// panicRecover catches any panics from the resolvers and sets an error
+// code of server failure
+func panicRecover(h dns.Handler) dns.Handler {
+	return dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				m := new(dns.Msg)
+				m.SetRcode(r, 2)
+				_ = w.WriteMsg(m)
+				logging.Error.Println(rec)
+			}
+		}()
+		h.ServeDNS(w, r)
+	})
+}
+
+// cleanWild strips any wildcards out thus mapping cleanly to the
+// original serviceName
+func cleanWild(dom string) string {
+	if strings.Contains(dom, ".*") {
+		return strings.Replace(dom, ".*", "", -1)
+	} else {
+		return dom
+	}
+}

--- a/resolver/http_plugin.go
+++ b/resolver/http_plugin.go
@@ -1,0 +1,203 @@
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful"
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/plugins"
+	"github.com/mesosphere/mesos-dns/util"
+)
+
+// HTTP API resolver plugin
+type APIPlugin struct {
+	res  *Resolver
+	ws   *restful.WebService
+	done chan struct{}
+}
+
+func NewAPIPlugin(res *Resolver) *APIPlugin {
+	api := &APIPlugin{
+		res:  res,
+		done: make(chan struct{}),
+	}
+	// webserver + available routes
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/v1/version").To(api.RestVersion))
+	ws.Route(ws.GET("/v1/config").To(api.RestConfig))
+	ws.Route(ws.GET("/v1/hosts/{host}").To(api.RestHost))
+	ws.Route(ws.GET("/v1/hosts/{host}/ports").To(api.RestPorts))
+	ws.Route(ws.GET("/v1/services/{service}").To(api.RestService))
+	api.ws = ws
+	return api
+}
+
+// starts an http server for mesos-dns queries, returns immediately
+func (api *APIPlugin) Start(ctx plugins.Context) <-chan error {
+	defer util.HandleCrash()
+
+	ctx.RegisterWS(api.ws)
+	portString := ":" + strconv.Itoa(api.res.config.HttpPort)
+	errCh := make(chan error, 1)
+	go func() {
+		select {
+		case <-api.done:
+			panic("plugin already terminated")
+		default:
+			defer close(api.done)
+		}
+
+		var err error
+		defer func() { errCh <- err }()
+
+		if err = http.ListenAndServe(portString, nil); err != nil {
+			err = fmt.Errorf("Failed to setup http server: %v", err)
+		} else {
+			logging.Error.Println("Not serving http requests any more.")
+		}
+	}()
+	return errCh
+}
+
+func (api *APIPlugin) Stop() {
+	//TODO(jdef)
+}
+
+func (api *APIPlugin) Done() <-chan struct{} {
+	return api.done
+}
+
+// Reports configuration through REST interface
+func (api *APIPlugin) RestConfig(req *restful.Request, resp *restful.Response) {
+	output, err := json.Marshal(api.res.config)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+
+	io.WriteString(resp, string(output))
+}
+
+// Reports Mesos-DNS version through REST interface
+func (api *APIPlugin) RestVersion(req *restful.Request, resp *restful.Response) {
+	mapV := map[string]string{"Service": "Mesos-DNS",
+		"Version": api.res.version,
+		"URL":     "https://github.com/mesosphere/mesos-dns"}
+	output, err := json.Marshal(mapV)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+	io.WriteString(resp, string(output))
+}
+
+// Reports Mesos-DNS version through http interface
+func (api *APIPlugin) RestHost(req *restful.Request, resp *restful.Response) {
+
+	host := req.PathParameter("host")
+	// clean up host name
+	dom := strings.ToLower(cleanWild(host))
+	if dom[len(dom)-1] != '.' {
+		dom += "."
+	}
+
+	mapH := make([]map[string]string, 0)
+	rs := api.res.records()
+
+	for _, ip := range rs.As[dom] {
+		t := map[string]string{"host": dom, "ip": ip}
+		mapH = append(mapH, t)
+	}
+	empty := (len(rs.As[dom]) == 0)
+	if empty {
+		t := map[string]string{"host": "", "ip": ""}
+		mapH = append(mapH, t)
+	}
+
+	output, err := json.Marshal(mapH)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+	io.WriteString(resp, string(output))
+
+	// stats
+	mesosrq := strings.HasSuffix(dom, api.res.config.Domain+".")
+	if mesosrq {
+		logging.CurLog.MesosRequests.Inc()
+		if empty {
+			logging.CurLog.MesosNXDomain.Inc()
+		} else {
+			logging.CurLog.MesosSuccess.Inc()
+		}
+	} else {
+		logging.CurLog.NonMesosRequests.Inc()
+		logging.CurLog.NonMesosFailed.Inc()
+	}
+
+}
+
+// Reports Mesos-DNS version through http interface
+func (api *APIPlugin) RestPorts(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "To be implemented...")
+}
+
+// Reports Mesos-DNS version through http interface
+func (api *APIPlugin) RestService(req *restful.Request, resp *restful.Response) {
+
+	var ip string
+
+	service := req.PathParameter("service")
+
+	// clean up service name
+	dom := strings.ToLower(cleanWild(service))
+	if dom[len(dom)-1] != '.' {
+		dom += "."
+	}
+
+	mapS := make([]map[string]string, 0)
+	rs := api.res.records()
+
+	for _, srv := range rs.SRVs[dom] {
+		h, port, _ := net.SplitHostPort(srv)
+		p, _ := strconv.Atoi(port)
+		if len(rs.As[h]) != 0 {
+			ip = rs.As[h][0]
+		} else {
+			ip = ""
+		}
+
+		t := map[string]string{"service": service, "host": h, "ip": ip, "port": strconv.Itoa(p)}
+		mapS = append(mapS, t)
+	}
+
+	empty := (len(rs.SRVs[dom]) == 0)
+	if empty {
+		t := map[string]string{"service": "", "host": "", "ip": "", "port": ""}
+		mapS = append(mapS, t)
+	}
+
+	output, err := json.Marshal(mapS)
+	if err != nil {
+		logging.Error.Println(err)
+	}
+	io.WriteString(resp, string(output))
+
+	// stats
+	mesosrq := strings.HasSuffix(dom, api.res.config.Domain+".")
+	if mesosrq {
+		logging.CurLog.MesosRequests.Inc()
+		if empty {
+			logging.CurLog.MesosNXDomain.Inc()
+		} else {
+			logging.CurLog.MesosSuccess.Inc()
+		}
+	} else {
+		logging.CurLog.NonMesosRequests.Inc()
+		logging.CurLog.NonMesosFailed.Inc()
+	}
+
+}

--- a/resolver/http_plugin.go
+++ b/resolver/http_plugin.go
@@ -52,7 +52,7 @@ func (api *APIPlugin) Start(ctx plugins.InitialContext) <-chan error {
 	ctx.RegisterWS(api.ws)
 	api.config = ctx.Config()
 
-	portString := ":" + strconv.Itoa(api.config.HttpPort)
+	portString := strconv.Itoa(api.config.HttpPort)
 	errCh := make(chan error, 1)
 	go func() {
 		select {
@@ -65,7 +65,13 @@ func (api *APIPlugin) Start(ctx plugins.InitialContext) <-chan error {
 		var err error
 		defer func() { errCh <- err }()
 
-		if err = http.ListenAndServe(portString, nil); err != nil {
+		var address string
+		if api.config.Listener != "" {
+			address = net.JoinHostPort(api.config.Listener, portString)
+		} else {
+			address = ":" + portString
+		}
+		if err = http.ListenAndServe(address, nil); err != nil {
 			err = fmt.Errorf("Failed to setup http server: %v", err)
 		} else {
 			logging.Error.Println("Not serving http requests any more.")

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -4,19 +4,15 @@ package resolver
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math/rand"
 	"net"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/emicklei/go-restful"
 	"github.com/mesos/mesos-go/detector"
 	_ "github.com/mesos/mesos-go/detector/zoo"
 	mesos "github.com/mesos/mesos-go/mesosproto"
@@ -483,167 +479,6 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 	if err != nil {
 		logging.Error.Println(err)
 	}
-}
-
-func (res *Resolver) configureHTTP() {
-	// webserver + available routes
-	ws := new(restful.WebService)
-	ws.Route(ws.GET("/v1/version").To(res.RestVersion))
-	ws.Route(ws.GET("/v1/config").To(res.RestConfig))
-	ws.Route(ws.GET("/v1/hosts/{host}").To(res.RestHost))
-	ws.Route(ws.GET("/v1/hosts/{host}/ports").To(res.RestPorts))
-	ws.Route(ws.GET("/v1/services/{service}").To(res.RestService))
-	restful.Add(ws)
-}
-
-// starts an http server for mesos-dns queries, returns immediately
-func (res *Resolver) LaunchHTTP() <-chan error {
-	defer util.HandleCrash()
-
-	res.configureHTTP()
-	portString := ":" + strconv.Itoa(res.config.HttpPort)
-
-	errCh := make(chan error, 1)
-	go func() {
-		var err error
-		defer func() { errCh <- err }()
-
-		if err = http.ListenAndServe(portString, nil); err != nil {
-			err = fmt.Errorf("Failed to setup http server: %v", err)
-		} else {
-			logging.Error.Println("Not serving http requests any more.")
-		}
-	}()
-	return errCh
-}
-
-// Reports configuration through REST interface
-func (res *Resolver) RestConfig(req *restful.Request, resp *restful.Response) {
-	output, err := json.Marshal(res.config)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-
-	io.WriteString(resp, string(output))
-}
-
-// Reports Mesos-DNS version through REST interface
-func (res *Resolver) RestVersion(req *restful.Request, resp *restful.Response) {
-	mapV := map[string]string{"Service": "Mesos-DNS",
-		"Version": res.version,
-		"URL":     "https://github.com/mesosphere/mesos-dns"}
-	output, err := json.Marshal(mapV)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-	io.WriteString(resp, string(output))
-}
-
-// Reports Mesos-DNS version through http interface
-func (res *Resolver) RestHost(req *restful.Request, resp *restful.Response) {
-
-	host := req.PathParameter("host")
-	// clean up host name
-	dom := strings.ToLower(cleanWild(host))
-	if dom[len(dom)-1] != '.' {
-		dom += "."
-	}
-
-	mapH := make([]map[string]string, 0)
-	rs := res.records()
-
-	for _, ip := range rs.As[dom] {
-		t := map[string]string{"host": dom, "ip": ip}
-		mapH = append(mapH, t)
-	}
-	empty := (len(rs.As[dom]) == 0)
-	if empty {
-		t := map[string]string{"host": "", "ip": ""}
-		mapH = append(mapH, t)
-	}
-
-	output, err := json.Marshal(mapH)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-	io.WriteString(resp, string(output))
-
-	// stats
-	mesosrq := strings.HasSuffix(dom, res.config.Domain+".")
-	if mesosrq {
-		logging.CurLog.MesosRequests.Inc()
-		if empty {
-			logging.CurLog.MesosNXDomain.Inc()
-		} else {
-			logging.CurLog.MesosSuccess.Inc()
-		}
-	} else {
-		logging.CurLog.NonMesosRequests.Inc()
-		logging.CurLog.NonMesosFailed.Inc()
-	}
-
-}
-
-// Reports Mesos-DNS version through http interface
-func (res *Resolver) RestPorts(req *restful.Request, resp *restful.Response) {
-	io.WriteString(resp, "To be implemented...")
-}
-
-// Reports Mesos-DNS version through http interface
-func (res *Resolver) RestService(req *restful.Request, resp *restful.Response) {
-
-	var ip string
-
-	service := req.PathParameter("service")
-
-	// clean up service name
-	dom := strings.ToLower(cleanWild(service))
-	if dom[len(dom)-1] != '.' {
-		dom += "."
-	}
-
-	mapS := make([]map[string]string, 0)
-	rs := res.records()
-
-	for _, srv := range rs.SRVs[dom] {
-		h, port, _ := net.SplitHostPort(srv)
-		p, _ := strconv.Atoi(port)
-		if len(rs.As[h]) != 0 {
-			ip = rs.As[h][0]
-		} else {
-			ip = ""
-		}
-
-		t := map[string]string{"service": service, "host": h, "ip": ip, "port": strconv.Itoa(p)}
-		mapS = append(mapS, t)
-	}
-
-	empty := (len(rs.SRVs[dom]) == 0)
-	if empty {
-		t := map[string]string{"service": "", "host": "", "ip": "", "port": ""}
-		mapS = append(mapS, t)
-	}
-
-	output, err := json.Marshal(mapS)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-	io.WriteString(resp, string(output))
-
-	// stats
-	mesosrq := strings.HasSuffix(dom, res.config.Domain+".")
-	if mesosrq {
-		logging.CurLog.MesosRequests.Inc()
-		if empty {
-			logging.CurLog.MesosNXDomain.Inc()
-		} else {
-			logging.CurLog.MesosSuccess.Inc()
-		}
-	} else {
-		logging.CurLog.NonMesosRequests.Inc()
-		logging.CurLog.NonMesosFailed.Inc()
-	}
-
 }
 
 // panicRecover catches any panics from the resolvers and sets an error

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -3,12 +3,6 @@
 package resolver
 
 import (
-	"errors"
-	"fmt"
-	"math/rand"
-	"net"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,11 +10,6 @@ import (
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/util"
-	"github.com/miekg/dns"
-)
-
-var (
-	recurseCnt = 3
 )
 
 // holds configuration state and the resource records
@@ -29,9 +18,7 @@ type Resolver struct {
 	config  records.Config
 	rs      *records.RecordSet
 	rsLock  sync.RWMutex
-
-	// pluggable external DNS resolution, mainly for unit testing
-	extResolver func(r *dns.Msg, nameserver string, proto string, cnt int) (*dns.Msg, error)
+	done    chan struct{}
 }
 
 func New(version string, config records.Config) *Resolver {
@@ -39,9 +26,13 @@ func New(version string, config records.Config) *Resolver {
 		version: version,
 		config:  config,
 		rs:      &records.RecordSet{},
+		done:    make(chan struct{}),
 	}
-	r.extResolver = r.defaultExtResolver
 	return r
+}
+
+func (res *Resolver) getVersion() string {
+	return res.version
 }
 
 // return the current (read-only) record set. attempts to write to the returned
@@ -52,59 +43,26 @@ func (res *Resolver) records() *records.RecordSet {
 	return res.rs
 }
 
-// launches DNS server for a resolver, returns immediately
-func (res *Resolver) LaunchDNS(applyFilters func(dns.Handler) dns.Handler) <-chan error {
-	// Handers for Mesos requests
-	dns.Handle(res.config.Domain+".", panicRecover(applyFilters(dns.HandlerFunc(res.HandleMesos))))
-	// Handler for nonMesos requests
-	dns.Handle(".", panicRecover(applyFilters(dns.HandlerFunc(res.HandleNonMesos))))
-
-	errCh := make(chan error, 2)
-	_, e1 := res.Serve("tcp")
-	go func() { errCh <- <-e1 }()
-	_, e2 := res.Serve("udp")
-	go func() { errCh <- <-e2 }()
-	return errCh
-}
-
-// starts a DNS server for net protocol (tcp/udp), returns immediately.
-// the returned signal chan is closed upon the server successfully entering the listening phase.
-// if the server aborts then an error is sent on the error chan.
-func (res *Resolver) Serve(net string) (<-chan struct{}, <-chan error) {
-	defer util.HandleCrash()
-
-	ch := make(chan struct{})
-	server := &dns.Server{
-		Addr:              res.config.Listener + ":" + strconv.Itoa(res.config.Port),
-		Net:               net,
-		TsigSecret:        nil,
-		NotifyStartedFunc: func() { close(ch) },
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		defer close(errCh)
-		err := server.ListenAndServe()
-		if err != nil {
-			errCh <- fmt.Errorf("Failed to setup %q server: %v", net, err)
-		} else {
-			logging.Error.Printf("Not listening/serving any more requests.")
-		}
-	}()
-	return ch, errCh
-}
-
 func (res *Resolver) Run(updates <-chan records.Update) {
-	util.Forever(func() { res.syncLoop(updates) }, 0)
+	util.Until(func() { res.syncLoop(updates) }, 0, res.done)
 }
 
 // syncLoop is the main loop for processing changes. It watches for changes from
 // the global update channel. For any new change seen, will run a sync against desired
 // state and running state. Never returns.
 func (res *Resolver) syncLoop(updates <-chan records.Update) {
+	select {
+	case <-res.done:
+		return
+	default:
+		// continue
+	}
 	for u := range updates {
 		res.updateRecords(u)
 	}
+	// only close the done chan if we exit normally, which means that the updates
+	// channel has closed and we are to terminate gracefully.
+	close(res.done)
 }
 
 func (res *Resolver) updateRecords(u records.Update) {
@@ -122,6 +80,10 @@ func (res *Resolver) updateRecords(u records.Update) {
 	}
 	timestamp := uint32(time.Now().Unix())
 	atomic.StoreUint32(&res.config.SOASerial, timestamp)
+}
+
+func (res *Resolver) getSOASerial() uint32 {
+	return atomic.LoadUint32(&res.config.SOASerial)
 }
 
 func applyUpdates(changed, current *records.RecordSet) *records.RecordSet {
@@ -145,332 +107,4 @@ func applyUpdates(changed, current *records.RecordSet) *records.RecordSet {
 		}
 	}
 	return updated
-}
-
-// defaultExtResolver queries other nameserver, potentially recurses; callers should probably be invoking extResolver
-// instead since that's the pluggable entrypoint into external resolution.
-func (res *Resolver) defaultExtResolver(r *dns.Msg, nameserver string, proto string, cnt int) (*dns.Msg, error) {
-	var in *dns.Msg
-	var err error
-
-	c := new(dns.Client)
-	c.Net = proto
-
-	var t time.Duration = 5 * 1e9
-	if res.config.Timeout != 0 {
-		t = time.Duration(int64(res.config.Timeout * 1e9))
-	}
-
-	c.DialTimeout = t
-	c.ReadTimeout = t
-	c.WriteTimeout = t
-
-	in, _, err = c.Exchange(r, nameserver)
-	if err != nil {
-		return in, err
-	}
-
-	// recurse
-	if (in != nil) && (len(in.Answer) == 0) && (!in.MsgHdr.Authoritative) && (len(in.Ns) > 0) && (err != nil) {
-
-		if cnt == recurseCnt {
-			logging.CurLog.NonMesosRecursed.Inc()
-		}
-
-		if cnt > 0 {
-			if soa, ok := (in.Ns[0]).(*dns.SOA); ok {
-				return res.defaultExtResolver(r, soa.Ns+":53", proto, cnt-1)
-			}
-		}
-
-	}
-
-	return in, err
-}
-
-// formatSRV returns the SRV resource record for target
-func (res *Resolver) formatSRV(name string, target string) (*dns.SRV, error) {
-	ttl := uint32(res.config.TTL)
-
-	h, port, err := net.SplitHostPort(target)
-	if err != nil {
-		return nil, errors.New("invalid target")
-	}
-	p, _ := strconv.Atoi(port)
-
-	return &dns.SRV{
-		Hdr: dns.RR_Header{
-			Name:   name,
-			Rrtype: dns.TypeSRV,
-			Class:  dns.ClassINET,
-			Ttl:    ttl,
-		},
-		Priority: 0,
-		Weight:   0,
-		Port:     uint16(p),
-		Target:   h,
-	}, nil
-}
-
-// returns the A resource record for target
-// assumes target is a well formed IPv4 address
-func (res *Resolver) formatA(dom string, target string) (*dns.A, error) {
-	ttl := uint32(res.config.TTL)
-
-	a := net.ParseIP(target)
-	if a == nil {
-		return nil, errors.New("invalid target")
-	}
-
-	return &dns.A{
-		Hdr: dns.RR_Header{
-			Name:   dom,
-			Rrtype: dns.TypeA,
-			Class:  dns.ClassINET,
-			Ttl:    ttl},
-		A: a.To4(),
-	}, nil
-}
-
-// formatSOA returns the SOA resource record for the mesos domain
-func (res *Resolver) formatSOA(dom string) (*dns.SOA, error) {
-	ttl := uint32(res.config.TTL)
-
-	return &dns.SOA{
-		Hdr: dns.RR_Header{
-			Name:   dom,
-			Rrtype: dns.TypeSOA,
-			Class:  dns.ClassINET,
-			Ttl:    ttl,
-		},
-		Ns:      res.config.SOARname,
-		Mbox:    res.config.SOAMname,
-		Serial:  atomic.LoadUint32(&res.config.SOASerial),
-		Refresh: res.config.SOARefresh,
-		Retry:   res.config.SOARetry,
-		Expire:  res.config.SOAExpire,
-		Minttl:  ttl,
-	}, nil
-}
-
-// formatNS returns the NS  record for the mesos domain
-func (res *Resolver) formatNS(dom string) (*dns.NS, error) {
-	ttl := uint32(res.config.TTL)
-
-	return &dns.NS{
-		Hdr: dns.RR_Header{
-			Name:   dom,
-			Rrtype: dns.TypeNS,
-			Class:  dns.ClassINET,
-			Ttl:    ttl,
-		},
-		Ns: res.config.SOAMname,
-	}, nil
-}
-
-// reorders answers for very basic load balancing
-func shuffleAnswers(answers []dns.RR) []dns.RR {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	n := len(answers)
-	for i := 0; i < n; i++ {
-		r := i + rand.Intn(n-i)
-		answers[r], answers[i] = answers[i], answers[r]
-	}
-
-	return answers
-}
-
-// makes non-mesos queries to external nameserver
-func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
-	var err error
-	var m *dns.Msg
-
-	// tracing info
-	logging.CurLog.NonMesosRequests.Inc()
-
-	// If external request are disabled
-	if !res.config.ExternalOn {
-		m = new(dns.Msg)
-		// set refused
-		m.SetRcode(r, 5)
-	} else {
-
-		proto := "udp"
-		if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
-			proto = "tcp"
-		}
-
-		for _, resolver := range res.config.Resolvers {
-			nameserver := resolver + ":53"
-			m, err = res.extResolver(r, nameserver, proto, recurseCnt)
-			if err == nil {
-				break
-			}
-		}
-	}
-
-	// extResolver returns nil Msg sometimes cause of perf
-	if m == nil {
-		m = new(dns.Msg)
-		m.SetRcode(r, 2)
-		err = errors.New("nil msg")
-	}
-	if err != nil {
-		logging.Error.Println(r.Question[0].Name)
-		logging.Error.Println(err)
-		logging.CurLog.NonMesosFailed.Inc()
-	} else {
-		// nxdomain
-		if len(m.Answer) == 0 {
-			logging.CurLog.NonMesosNXDomain.Inc()
-		} else {
-			logging.CurLog.NonMesosSuccess.Inc()
-		}
-	}
-
-	err = w.WriteMsg(m)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-}
-
-// HandleMesos is a resolver request handler that responds to a resource
-// question with resource answer(s)
-// it can handle {A, SRV, ANY}
-func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
-	var err error
-
-	dom := strings.ToLower(cleanWild(r.Question[0].Name))
-	qType := r.Question[0].Qtype
-
-	m := new(dns.Msg)
-	m.Authoritative = true
-	m.RecursionAvailable = res.config.RecurseOn
-	m.SetReply(r)
-
-	rs := res.records()
-
-	// SRV requests
-	if (qType == dns.TypeSRV) || (qType == dns.TypeANY) {
-		for _, srv := range rs.SRVs[dom] {
-			rr, err := res.formatSRV(r.Question[0].Name, srv)
-			if err != nil {
-				logging.Error.Println(err)
-			} else {
-				m.Answer = append(m.Answer, rr)
-				// return one corresponding A record add additional info
-				host := strings.Split(srv, ":")[0]
-				if len(rs.As[host]) != 0 {
-					rr, err := res.formatA(host, rs.As[host][0])
-					if err != nil {
-						logging.Error.Println(err)
-					} else {
-						m.Extra = append(m.Extra, rr)
-					}
-				}
-
-			}
-		}
-	}
-
-	// A requests
-	if (qType == dns.TypeA) || (qType == dns.TypeANY) {
-		for _, a := range rs.As[dom] {
-			rr, err := res.formatA(dom, a)
-			if err != nil {
-				logging.Error.Println(err)
-			} else {
-				m.Answer = append(m.Answer, rr)
-			}
-
-		}
-	}
-
-	// SOA requests
-	if (qType == dns.TypeSOA) || (qType == dns.TypeANY) {
-		rr, err := res.formatSOA(r.Question[0].Name)
-		if err != nil {
-			logging.Error.Println(err)
-		} else {
-			m.Ns = append(m.Ns, rr)
-		}
-	}
-
-	// NS requests
-	if (qType == dns.TypeNS) || (qType == dns.TypeANY) {
-		rr, err := res.formatNS(r.Question[0].Name)
-		logging.Error.Println("NS request")
-		if err != nil {
-			logging.Error.Println(err)
-		} else {
-			m.Ns = append(m.Ns, rr)
-		}
-	}
-
-	// shuffle answers
-	m.Answer = shuffleAnswers(m.Answer)
-	// tracing info
-	logging.CurLog.MesosRequests.Inc()
-
-	if err != nil {
-		logging.CurLog.MesosFailed.Inc()
-	} else if (qType == dns.TypeAAAA) && (len(rs.SRVs[dom]) > 0 || len(rs.As[dom]) > 0) {
-		// correct handling of AAAA if there are A or SRV records
-		m.Authoritative = true
-		// set NOERROR
-		m.SetRcode(r, 0)
-		// leave answer empty (NOERROR --> NODATA)
-
-	} else {
-		// no answers but not a {SOA,SRV} request
-		if len(m.Answer) == 0 && (qType != dns.TypeSOA) && (qType != dns.TypeNS) && (qType != dns.TypeSRV) {
-			// set NXDOMAIN
-			m.SetRcode(r, 3)
-
-			rr, err := res.formatSOA(r.Question[0].Name)
-			if err != nil {
-				logging.Error.Println(err)
-			} else {
-				m.Ns = append(m.Ns, rr)
-			}
-
-			logging.CurLog.MesosNXDomain.Inc()
-			logging.VeryVerbose.Println("total A rrs:\t" + strconv.Itoa(len(rs.As)))
-			logging.VeryVerbose.Println("failed looking for " + r.Question[0].String())
-		} else {
-			logging.CurLog.MesosSuccess.Inc()
-		}
-	}
-
-	err = w.WriteMsg(m)
-	if err != nil {
-		logging.Error.Println(err)
-	}
-}
-
-// panicRecover catches any panics from the resolvers and sets an error
-// code of server failure
-func panicRecover(h dns.Handler) dns.Handler {
-	return dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		defer func() {
-			if rec := recover(); rec != nil {
-				m := new(dns.Msg)
-				m.SetRcode(r, 2)
-				_ = w.WriteMsg(m)
-				logging.Error.Println(rec)
-			}
-		}()
-		h.ServeDNS(w, r)
-	})
-}
-
-// cleanWild strips any wildcards out thus mapping cleanly to the
-// original serviceName
-func cleanWild(dom string) string {
-	if strings.Contains(dom, ".*") {
-		return strings.Replace(dom, ".*", "", -1)
-	} else {
-		return dom
-	}
 }

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -2,9 +2,6 @@ package resolver
 
 import (
 	"encoding/json"
-	"github.com/mesosphere/mesos-dns/logging"
-	"github.com/mesosphere/mesos-dns/records"
-	"github.com/miekg/dns"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +10,11 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/emicklei/go-restful"
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/miekg/dns"
 )
 
 func init() {
@@ -339,7 +341,8 @@ func TestHTTP(t *testing.T) {
 	}
 	res.version = "0.1.1"
 
-	res.configureHTTP()
+	plugin := NewAPIPlugin(res)
+	restful.Add(plugin.ws)
 	ts := httptest.NewServer(http.DefaultServeMux)
 	defer ts.Close()
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -343,6 +343,8 @@ func TestHTTP(t *testing.T) {
 
 	plugin := NewAPIPlugin(res)
 	restful.Add(plugin.ws)
+	plugin.config = &res.config
+
 	ts := httptest.NewServer(http.DefaultServeMux)
 	defer ts.Close()
 

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+
+	"github.com/mesosphere/mesos-dns/util"
+)
+
+type Merger interface {
+	// Invoked when a change from a source is received.  May also function as an incremental
+	// merger if you wish to consume changes incrementally.  Must be reentrant when more than
+	// one source is defined.
+	Merge(source string, update interface{}) error
+}
+
+// MergeFunc implements the Merger interface
+type MergeFunc func(source string, update interface{}) error
+
+func (f MergeFunc) Merge(source string, update interface{}) error {
+	return f(source, update)
+}
+
+// Mux is a class for merging configuration from multiple sources.  Changes are
+// pushed via channels and sent to the merge function.
+type Mux struct {
+	// Invoked when an update is sent to a source.
+	merger Merger
+
+	// Sources and their lock.
+	sourceLock sync.RWMutex
+	// Maps source names to channels
+	sources map[string]chan interface{}
+}
+
+// NewMux creates a new mux that can merge changes from multiple sources.
+func NewMux(merger Merger) *Mux {
+	mux := &Mux{
+		sources: make(map[string]chan interface{}),
+		merger:  merger,
+	}
+	return mux
+}
+
+// Channel returns a channel where a configuration source
+// can send updates of new configurations. Multiple calls with the same
+// source will return the same channel. This allows change and state based sources
+// to use the same channel. Different source names however will be treated as a
+// union.
+func (m *Mux) Channel(source string) chan interface{} {
+	if len(source) == 0 {
+		panic("Channel given an empty name")
+	}
+	m.sourceLock.Lock()
+	defer m.sourceLock.Unlock()
+	channel, exists := m.sources[source]
+	if exists {
+		return channel
+	}
+	newChannel := make(chan interface{})
+	m.sources[source] = newChannel
+	go util.Forever(func() { m.listen(source, newChannel) }, 0)
+	return newChannel
+}
+
+func (m *Mux) listen(source string, listenChannel <-chan interface{}) {
+	for update := range listenChannel {
+		m.merger.Merge(source, update)
+	}
+}
+
+// Accessor is an interface for retrieving the current merge state.
+type Accessor interface {
+	// MergedState returns a representation of the current merge state.
+	// Must be reentrant when more than one source is defined.
+	MergedState() interface{}
+}
+
+// AccessorFunc implements the Accessor interface.
+type AccessorFunc func() interface{}
+
+func (f AccessorFunc) MergedState() interface{} {
+	return f()
+}
+
+type Listener interface {
+	// OnUpdate is invoked when a change is made to an object.
+	OnUpdate(instance interface{})
+}
+
+// ListenerFunc receives a representation of the change or object.
+type ListenerFunc func(instance interface{})
+
+func (f ListenerFunc) OnUpdate(instance interface{}) {
+	f(instance)
+}
+
+type Broadcaster struct {
+	// Listeners for changes and their lock.
+	listenerLock sync.RWMutex
+	listeners    []Listener
+}
+
+// NewBroadcaster registers a set of listeners that support the Listener interface
+// and notifies them all on changes.
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{}
+}
+
+// Add registers listener to receive updates of changes.
+func (b *Broadcaster) Add(listener Listener) {
+	b.listenerLock.Lock()
+	defer b.listenerLock.Unlock()
+	b.listeners = append(b.listeners, listener)
+}
+
+// Notify notifies all listeners.
+func (b *Broadcaster) Notify(instance interface{}) {
+	b.listenerLock.RLock()
+	listeners := b.listeners
+	b.listenerLock.RUnlock()
+	for _, listener := range listeners {
+		listener.OnUpdate(instance)
+	}
+}

--- a/util/config/config_test.go
+++ b/util/config/config_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigurationChannels(t *testing.T) {
+	mux := NewMux(nil)
+	channelOne := mux.Channel("one")
+	if channelOne != mux.Channel("one") {
+		t.Error("Didn't get the same muxuration channel back with the same name")
+	}
+	channelTwo := mux.Channel("two")
+	if channelOne == channelTwo {
+		t.Error("Got back the same muxuration channel for different names")
+	}
+}
+
+type MergeMock struct {
+	source string
+	update interface{}
+	t      *testing.T
+}
+
+func (m MergeMock) Merge(source string, update interface{}) error {
+	if m.source != source {
+		m.t.Errorf("Expected %s, Got %s", m.source, source)
+	}
+	if !reflect.DeepEqual(m.update, update) {
+		m.t.Errorf("Expected %s, Got %s", m.update, update)
+	}
+	return nil
+}
+
+func TestMergeInvoked(t *testing.T) {
+	merger := MergeMock{"one", "test", t}
+	mux := NewMux(&merger)
+	mux.Channel("one") <- "test"
+}
+
+func TestMergeFuncInvoked(t *testing.T) {
+	ch := make(chan bool)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		if source != "one" {
+			t.Errorf("Expected %s, Got %s", "one", source)
+		}
+		if update.(string) != "test" {
+			t.Errorf("Expected %s, Got %s", "test", update)
+		}
+		ch <- true
+		return nil
+	}))
+	mux.Channel("one") <- "test"
+	<-ch
+}
+
+func TestSimultaneousMerge(t *testing.T) {
+	ch := make(chan bool, 2)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		switch source {
+		case "one":
+			if update.(string) != "test" {
+				t.Errorf("Expected %s, Got %s", "test", update)
+			}
+		case "two":
+			if update.(string) != "test2" {
+				t.Errorf("Expected %s, Got %s", "test2", update)
+			}
+		default:
+			t.Errorf("Unexpected source, Got %s", update)
+		}
+		ch <- true
+		return nil
+	}))
+	source := mux.Channel("one")
+	source2 := mux.Channel("two")
+	source <- "test"
+	source2 <- "test2"
+	<-ch
+	<-ch
+}
+
+func TestBroadcaster(t *testing.T) {
+	b := NewBroadcaster()
+	b.Notify(struct{}{})
+
+	ch := make(chan bool, 2)
+	b.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	b.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	b.Notify("test")
+	<-ch
+	<-ch
+}

--- a/util/config/doc.go
+++ b/util/config/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config provides utility objects for decoupling sources of configuration and the
+// actual configuration state. Consumers must implement the Merger interface to unify
+// the sources of change into an object.
+package config

--- a/util/set.go
+++ b/util/set.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"sort"
+)
+
+type empty struct{}
+
+// StringSet is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
+type StringSet map[string]empty
+
+// NewStringSet creates a StringSet from a list of values.
+func NewStringSet(items ...string) StringSet {
+	ss := StringSet{}
+	ss.Insert(items...)
+	return ss
+}
+
+// KeySet creates a StringSet from a keys of a map[string](? extends interface{}).  Since you can't describe that map type in the Go type system
+// the reflected value is required.
+func KeySet(theMap reflect.Value) StringSet {
+	ret := StringSet{}
+
+	for _, keyValue := range theMap.MapKeys() {
+		ret.Insert(keyValue.String())
+	}
+
+	return ret
+}
+
+// Insert adds items to the set.
+func (s StringSet) Insert(items ...string) {
+	for _, item := range items {
+		s[item] = empty{}
+	}
+}
+
+// Delete removes all items from the set.
+func (s StringSet) Delete(items ...string) {
+	for _, item := range items {
+		delete(s, item)
+	}
+}
+
+// Has returns true iff item is contained in the set.
+func (s StringSet) Has(item string) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true iff all items are contained in the set.
+func (s StringSet) HasAll(items ...string) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s StringSet) HasAny(items ...string) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {1, 2, 3}
+// s2 = {1, 2, 4, 5}
+// s1.Difference(s2) = {3}
+// s2.Difference(s1) = {4, 5}
+func (s StringSet) Difference(s2 StringSet) StringSet {
+	result := NewStringSet()
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// vof objects that are not in s2
+// For example:
+// s1 = {1, 2}
+// s2 = {3, 4}
+// s1.Union(s2) = {1, 2, 3, 4}
+// s2.Union(s1) = {1, 2, 3, 4}
+func (s1 StringSet) Union(s2 StringSet) StringSet {
+	result := NewStringSet()
+	for key := range s1 {
+		result.Insert(key)
+	}
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// IsSuperset returns true iff s1 is a superset of s2.
+func (s1 StringSet) IsSuperset(s2 StringSet) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// List returns the contents as a sorted string slice.
+func (s StringSet) List() []string {
+	res := make([]string, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.StringSlice(res).Sort()
+	return res
+}
+
+// Returns a single element from the set.
+func (s StringSet) PopAny() (string, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	return "", false
+}
+
+// Len returns the size of the set.
+func (s StringSet) Len() int {
+	return len(s)
+}

--- a/util/set_test.go
+++ b/util/set_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringSet(t *testing.T) {
+	s := StringSet{}
+	s2 := StringSet{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	s.Insert("a", "b")
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert("c")
+	if s.Has("d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("a") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete("a")
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert("a")
+	if s.HasAll("a", "b", "d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll("a", "b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert("a", "b", "d")
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete("d")
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestStringSetDeleteMultiples(t *testing.T) {
+	s := StringSet{}
+	s.Insert("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete("a", "c")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+
+}
+
+func TestNewStringSet(t *testing.T) {
+	s := NewStringSet("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestStringSetList(t *testing.T) {
+	s := NewStringSet("z", "y", "x", "a")
+	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
+		t.Errorf("List gave unexpected result: %#v", s.List())
+	}
+}
+
+func TestStringSetDifference(t *testing.T) {
+	a := NewStringSet("1", "2", "3")
+	b := NewStringSet("1", "2", "4", "5")
+	c := a.Difference(b)
+	d := b.Difference(a)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has("3") {
+		t.Errorf("Unexpected contents: %#v", c.List())
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has("4") || !d.Has("5") {
+		t.Errorf("Unexpected contents: %#v", d.List())
+	}
+}
+
+func TestStringSetHasAny(t *testing.T) {
+	a := NewStringSet("1", "2", "3")
+
+	if !a.HasAny("1", "4") {
+		t.Errorf("expected true, got false")
+	}
+
+	if a.HasAny("0", "4") {
+		t.Errorf("expected false, got true")
+	}
+}


### PR DESCRIPTION
- supersedes #110 
- fixes #62
- high-level changelog
  - hide master polling implementation behind event (`records/config`) model
    - we still poll master :(
    - plugins don't have to poll, they can push
  - plugins!
    - can register additional HTTP containers
    - can register pre/post processing filters for records generated from mesos tasks
    - can wrap the record generation function for tasks records
    - can register additional record sources
    - HTTP and DNS servers both run as plugins
- TODO
  - [ ] document features, provide examples, add more tests
