### PR TITLE
resolver: Compress all DNS answers

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -349,8 +349,8 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	err = w.WriteMsg(m)
-	if err != nil {
+	m.Compress = true
+	if err = w.WriteMsg(m); err != nil {
 		logging.Error.Println(err)
 	}
 }
@@ -463,8 +463,8 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	err = w.WriteMsg(m)
-	if err != nil {
+	m.Compress = true
+	if err = w.WriteMsg(m); err != nil {
 		logging.Error.Println(err)
 	}
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -349,10 +349,7 @@ func (res *Resolver) HandleNonMesos(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	m.Compress = true
-	if err = w.WriteMsg(truncate(m, isUDP(w))); err != nil {
-		logging.Error.Println(err)
-	}
+	reply(w, m)
 }
 
 // HandleMesos is a resolver request handler that responds to a resource
@@ -463,8 +460,14 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	m.Compress = true
-	if err = w.WriteMsg(truncate(m, isUDP(w))); err != nil {
+	reply(w, m)
+}
+
+// reply writes the given dns.Msg out to the given dns.ResponseWriter,
+// compressing the message first and truncating it accordingly.
+func reply(w dns.ResponseWriter, m *dns.Msg) {
+	m.Compress = true // https://github.com/mesosphere/mesos-dns/issues/{170,173,174}
+	if err := w.WriteMsg(truncate(m, isUDP(w))); err != nil {
 		logging.Error.Println(err)
 	}
 }


### PR DESCRIPTION
This patch makes mesos-dns compress all DNS answers. This improves
performance of many DNS questions which, when compressed, fit in 512
bytes. See https://tools.ietf.org/html/rfc1035#section-4.2.1

Fixes #170 because the native Go DNS resolver which is enabled when
statically compiling [doesn't fallback to TCP](https://github.com/golang/go/blob/master/src/net/dnsclient_unix.go#L147) when [failing to decode](https://github.com/golang/go/blob/master/src/net/dnsclient_unix.go#L49)
a UDP response larger than 512 bytes.

It isn't a perfect solution since an answer might be larger than 512
bytes even after compression but that's an issue with the client
resolver.