### PR TITLE
Add _container.task.framework.mesos A records with container IP

### DIFF
--- a/factories/fake.json
+++ b/factories/fake.json
@@ -186,7 +186,13 @@
                     "statuses": [
                         {
                             "state": "TASK_RUNNING",
-                            "timestamp": 1409096598.68885
+                            "timestamp": 1409096598.68885,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -206,7 +212,49 @@
                     "statuses": [
                         {
                             "state": "TASK_RUNNING",
-                            "timestamp": 1413572390.09275
+                            "timestamp": 1413572371.04321,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "Docker.NetworkSettings.IPAddress",
+                                    "value": "10.3.0.4"
+                                }
+                            ]
+                        },
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1413572390.09275,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "Docker.NetworkSettings.IPAddress",
+                                    "value": "10.3.0.1"
+                                }
+                            ]
+                        },
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1413572381.0123,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "container-ip",
+                                    "value": ""
+                                }
+                            ]
+                        },
+                        {
+                            "state": "TASK_STARTING",
+                            "timestamp": 1413572380.01234
                         }
                     ]
                 },
@@ -226,7 +274,17 @@
                     "statuses": [
                         {
                             "state": "TASK_RUNNING",
-                            "timestamp": 1413572383.04559
+                            "timestamp": 1413572383.04559,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "Docker.NetworkSettings.IPAddress",
+                                    "value": "10.3.0.2"
+                                }
+                            ]
                         }
                     ]
                 },

--- a/records/generator.go
+++ b/records/generator.go
@@ -25,9 +25,9 @@ type rrs map[string][]string
 // Mesos-DNS state
 // Refactor when discovery id is available
 type RecordGenerator struct {
-	As     rrs
-	SRVs   rrs
-	Slaves map[string]string
+	As       rrs
+	SRVs     rrs
+	SlaveIPs map[string]string
 }
 
 // The following types help parse state.json
@@ -236,9 +236,9 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, ns string,
 	listener string, masters []string, spec labels.HostNameSpec) error {
 
 	// creates a map with slave IP addresses (IPv4)
-	rg.Slaves = make(map[string]string)
+	rg.SlaveIPs = make(map[string]string)
 	for _, slave := range sj.Slaves {
-		rg.Slaves[slave.Id] = sanitizedSlaveAddress(slave.Hostname, spec)
+		rg.SlaveIPs[slave.Id] = sanitizedSlaveAddress(slave.Hostname, spec)
 	}
 
 	rg.SRVs = make(rrs)
@@ -261,9 +261,9 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, ns string,
 
 			// A records for task and task-sid
 			arec := tname + "." + tail
-			rg.insertRR(arec, host, "A")
+			rg.insertRR(arec, hostIP, "A")
 			trec := tname + "-" + tag + "-" + sid + "." + tail
-			rg.insertRR(trec, host, "A")
+			rg.insertRR(trec, hostIP, "A")
 
 			// SRV records
 			if task.Resources.Ports != "" {

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -255,14 +255,30 @@ func TestInsertState(t *testing.T) {
 		t.Error("should not find this not-running task - SRV record")
 	}
 
-	_, ok = rg.As["liquor-store.marathon.mesos."]
+	rrs, ok := rg.As["liquor-store.marathon.mesos."]
 	if !ok {
 		t.Error("should find this running task - A record")
+	}
+	if got, want := rrs, []string{"1.2.3.11", "1.2.3.12"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("should return the slave ips 1.2.3.11, 1.2.3.12 for the task, but got %v", rrs)
+	}
+
+	rrs, ok = rg.As["_container.liquor-store.marathon.mesos."]
+	if !ok {
+		t.Error("should find the container ip")
+	}
+	if got, want := rrs, []string{"10.3.0.1", "10.3.0.2"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("should return the container IPs 10.3.0.1, 10.3.0.2 for the task, but got %v", rrs)
 	}
 
 	_, ok = rg.As["poseidon.marathon.mesos."]
 	if ok {
 		t.Error("should not find this not-running task - A record")
+	}
+
+	_, ok = rg.As["_container.poseidon.marathon.mesos."]
+	if ok {
+		t.Error("should not find a container IP")
 	}
 
 	_, ok = rg.As["master.mesos."]
@@ -286,13 +302,13 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// test for 10 SRV names
-	if len(rg.SRVs) != 10 {
-		t.Error("not enough SRVs")
+	if got, want := len(rg.SRVs), 10; got != want {
+		t.Errorf("not enough SRVs, got %d, expected %d", got, want)
 	}
 
 	// test for 5 A names
-	if len(rg.As) != 13 {
-		t.Error("not enough As")
+	if got, want := len(rg.As), 16; got != want {
+		t.Errorf("not enough As, got %d, expected %d", got, want)
 	}
 
 	// ensure we translate the framework name as well
@@ -302,7 +318,7 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// ensure we find this SRV
-	rrs := rg.SRVs["_liquor-store._tcp.marathon.mesos."]
+	rrs = rg.SRVs["_liquor-store._tcp.marathon.mesos."]
 	// ensure there are 3 RRDATA answers for this SRV name
 	if len(rrs) != 3 {
 		t.Error("not enough SRV records")

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -231,17 +231,16 @@ func TestLeaderIP(t *testing.T) {
 
 // ensure we are parsing what we think we are
 func TestInsertState(t *testing.T) {
-
 	var sj StateJSON
 
 	b, err := ioutil.ReadFile("../factories/fake.json")
 	if err != nil {
-		t.Error("missing test data")
+		t.Fatal("missing test data")
 	}
 
 	err = json.Unmarshal(b, &sj)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	sj.Leader = "master@144.76.157.37:5050"
 


### PR DESCRIPTION
For each existing A record for a task with a container IP another A record is added with the `_container` prefix, resolving to the container IP instead of the host IP.

The container IP is passed in a status label of a task in state.json, e.g. 

```json
{
  "executor_id": "",
  "framework_id": "20140703-014514-3041283216-5050-5348-0000",
  "id": "liquor-store.b8db9f73-562f-11e4-a088-c20493233aa5",
  "name": "liquor-store",
  "slave_id": "20140803-125133-3041283216-5050-2410-0",
  "state": "TASK_RUNNING",
  "statuses": [
    {
      "state": "TASK_RUNNING",
      "timestamp": 1413572390.09275,
      "labels": [
        {
          "key": "Docker.NetworkSettings.IPAddress",
          "value": "10.3.0.1"
        }
      ]
    }
  ]
}
```


Compare https://reviews.apache.org/r/36537/ and https://issues.apache.org/jira/browse/MESOS-3076