### PR TITLE
downgrade log level of debug message

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -415,7 +415,7 @@ func (res *Resolver) HandleMesos(w dns.ResponseWriter, r *dns.Msg) {
 	// NS requests
 	if (qType == dns.TypeNS) || (qType == dns.TypeANY) {
 		rr, err := res.formatNS(r.Question[0].Name)
-		logging.Error.Println("NS request")
+		logging.VeryVerbose.Println("NS request")
 		if err != nil {
 			logging.Error.Println(err)
 		} else {


### PR DESCRIPTION
a customer was concerned about an ERROR message in the mesos-dns logs. since it's not really an error, we shouldn't log it that way. we can probably do away with this line eventually, but for now I'm simply downgrading it from "Error" to "VeryVerbose".
