### PR TITLE
add A record slave.<domain> to contain list of slave IPs

### DIFF
--- a/records/generator.go
+++ b/records/generator.go
@@ -271,12 +271,15 @@ func (rg *RecordGenerator) InsertState(sj StateJSON, domain string, ns string,
 
 	// creates a map with slave IP addresses (IPv4)
 	rg.SlaveIPs = make(map[string]string)
-	for _, slave := range sj.Slaves {
-		rg.SlaveIPs[slave.ID] = sanitizedSlaveAddress(slave.Hostname, spec)
-	}
-
 	rg.SRVs = make(rrs)
 	rg.As = make(rrs)
+
+	for _, slave := range sj.Slaves {
+		ssa := sanitizedSlaveAddress(slave.Hostname, spec)
+		rg.SlaveIPs[slave.ID] = ssa
+		rg.insertRR("slave."+domain+".", ssa, "A")
+	}
+
 
 	// complete crap - refactor me
 	for _, f := range sj.Frameworks {

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -287,6 +287,14 @@ func TestInsertState(t *testing.T) {
 		t.Error("should find a running master - A record")
 	}
 
+	rrs, ok = rg.As["slave.mesos."]
+	if !ok {
+		t.Error("should find a running slave - A record")
+	}
+	if got, want := rrs, []string{"1.2.3.10", "1.2.3.11", "1.2.3.12"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("should return the slave ips %v for the slave record, but got %v", want, got)
+	}
+
 	_, ok = rg.As["master0.mesos."]
 	if !ok {
 		t.Error("should find a running master0 - A record")
@@ -308,7 +316,7 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// test for 5 A names
-	if got, want := len(rg.As), 16; got != want {
+	if got, want := len(rg.As), 17; got != want {
 		t.Errorf("not enough As, got %d, expected %d", got, want)
 	}
 


### PR DESCRIPTION
This allows me to resolve slave.mesos and get a list of all slave IPs.
We'd like to use this for our dreamathon monitoring project which is supposed to run on DCOS and monitor the state of all mesos slaves.

In a second step I'd also like to add appropriate SRV records, but couldn't find an easy way to get the slave port out of the current data structure.