### PR TITLE
Add container ip label MesosContainerizer.NetworkSettings.IPAddress and remove _container prefix

### DIFF
--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -28,7 +28,8 @@ The configuration file should include the following fields:
   "SOARefresh": 60,
   "SOARetry":   600,
   "SOAExpire":  86400,
-  "SOAMinttl": 60
+  "SOAMinttl": 60,
+  "ContainerIPsOn": true
 }
 ```
 
@@ -73,3 +74,6 @@ It is sufficient to specify just one of the `zk` or `masters` field. If both are
 `recurseon` controls if the DNS replies for names in the Mesos domain will indicate that recursion is available. The default value is `true`. 
 
 `enforceRFC952` will enforce an older, more strict set of rules for DNS labels. For details, see the [RFC-952](https://tools.ietf.org/html/rfc952). The default value is `false`.
+
+`ContainerIPsOn` controls whether A records with the container IP are created instead of the slave IP if one of task status labels `Docker.NetworkSettings.IPAddress` or `MesosContainerizer.NetworkSettings.IPAddress` is set by Mesos or the executor.
+The default value is `true`.

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -26,11 +26,36 @@ $ dig search.marathon.mesos
 search.marathon.mesos.		60	IN	A	10.9.87.94
 ```
  
+## Container IP A Records
+
+The A records above point to the host IP of a given service. If container IPs are supported by Mesos and the executor of a test, Mesos-DNS will create another A record for each of the A records above by prefixing it with `_container` and returning the container IP:
+
+``` console
+$ dig _container.search.marathon.mesos
+
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> _container.search.marathon.mesos
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24471
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;_container.search.marathon.mesos.         IN  A
+
+;; ANSWER SECTION:
+_container.search.marathon.mesos.      60  IN  A   10.0.3.72
+```
+
+*Note*: Container IPs must be provided by the executor of a task in one of the following task status labels:
+- `Docker.NetworkSettings.IPAddress`
+- `MesosContainerizer.NetworkSettings.IPAddress`.
+In general support for these will not be available before Mesos 0.24.
+
 ## SRV Records
 
 An SRV record associates a service name to a hostname and an IP port.  For task `task` launched by framework `framework`, Mesos-DNS generates an SRV record for service name `_task._protocol.framework.domain`, where `protocol` is `udp` or `tcp`. For example, other Mesos tasks can discover service `search` launched by the `marathon` framework with a lookup for lookup `_search._tcp.marathon.mesos`:
 
-``` console
+```console
 $ dig _search._tcp.marathon.mesos SRV
 
 ; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> _search._tcp.marathon.mesos SRV
@@ -44,7 +69,7 @@ $ dig _search._tcp.marathon.mesos SRV
 
 ;; ANSWER SECTION:
 _search._tcp.marathon.mesos.	60 IN SRV 0 0 31302 10.254.132.41.
-``` 
+```
 
 SRV records are generated only for tasks that have been allocated a specific port through Mesos. 
 

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -8,7 +8,10 @@ Mesos-DNS defines a DNS domain for Mesos tasks (default `.mesos`, see [instructi
 
 ## A Records
 
-An A record associates a hostname to an IP address. For task `task` launched by framework `framework`, Mesos-DNS generates an A record for hostname `task.framework.domain` that provides the IP address of the specific slave running the task. For example, other Mesos tasks can discover the IP address for service `search` launched by the `marathon` framework with a lookup for `search.marathon.mesos`:
+An A record associates a hostname to an IP address. For task `task` launched by framework `framework`, Mesos-DNS generates an A record for hostname `task.framework.domain` that provides
+- either the IP address of the specific slave running the task
+- or the IP address of the task container itself if Mesos provides this (in the task status labels).
+For example, other Mesos tasks can discover the IP address for service `search` launched by the `marathon` framework with a lookup for `search.marathon.mesos`:
 
 ``` console
 $ dig search.marathon.mesos
@@ -25,25 +28,23 @@ $ dig search.marathon.mesos
 ;; ANSWER SECTION:
 search.marathon.mesos.		60	IN	A	10.9.87.94
 ```
- 
-## Container IP A Records
 
-The A records above point to the host IP of a given service. If container IPs are supported by Mesos and the executor of a test, Mesos-DNS will create another A record for each of the A records above by prefixing it with `_container` and returning the container IP:
+If Mesos is setup to provide a container IP `10.0.4.1` for the task `search.marathon.mesos` the lookup would give:
 
 ``` console
-$ dig _container.search.marathon.mesos
+$ dig search.marathon.mesos
 
-; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> _container.search.marathon.mesos
+; <<>> DiG 9.8.4-rpz2+rl005.12-P1 <<>> search.marathon.mesos
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24471
 ;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 0
 
 ;; QUESTION SECTION:
-;_container.search.marathon.mesos.         IN  A
+;search.marathon.mesos.         IN  A
 
 ;; ANSWER SECTION:
-_container.search.marathon.mesos.      60  IN  A   10.0.3.72
+search.marathon.mesos.      60  IN  A   10.0.4.1
 ```
 
 *Note*: Container IPs must be provided by the executor of a task in one of the following task status labels:
@@ -71,7 +72,7 @@ $ dig _search._tcp.marathon.mesos SRV
 _search._tcp.marathon.mesos.	60 IN SRV 0 0 31302 10.254.132.41.
 ```
 
-SRV records are generated only for tasks that have been allocated a specific port through Mesos. 
+*Note*: SRV records are generated only for tasks that have been allocated a specific port through Mesos and that have no container IP assigned.
 
 ## Other Records
 

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -9,8 +9,10 @@ Mesos-DNS defines a DNS domain for Mesos tasks (default `.mesos`, see [instructi
 ## A Records
 
 An A record associates a hostname to an IP address. For task `task` launched by framework `framework`, Mesos-DNS generates an A record for hostname `task.framework.domain` that provides
+
 - either the IP address of the specific slave running the task
 - or the IP address of the task container itself if Mesos provides this (in the task status labels).
+
 For example, other Mesos tasks can discover the IP address for service `search` launched by the `marathon` framework with a lookup for `search.marathon.mesos`:
 
 ``` console
@@ -48,8 +50,10 @@ search.marathon.mesos.      60  IN  A   10.0.4.1
 ```
 
 *Note*: Container IPs must be provided by the executor of a task in one of the following task status labels:
+
 - `Docker.NetworkSettings.IPAddress`
 - `MesosContainerizer.NetworkSettings.IPAddress`.
+
 In general support for these will not be available before Mesos 0.24.
 
 ## SRV Records

--- a/factories/fake.json
+++ b/factories/fake.json
@@ -324,7 +324,17 @@
                     "statuses": [
                         {
                             "state": "TASK_RUNNING",
-                            "timestamp": 1414800227.3456
+                            "timestamp": 1414800227.3456,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                },
+                                {
+                                    "key": "MesosContainerizer.NetworkSettings.IPAddress",
+                                    "value": "10.5.0.7"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/factories/fake.json
+++ b/factories/fake.json
@@ -174,7 +174,7 @@
                     "executor_id": "",
                     "framework_id": "20140703-014514-3041283216-5050-5348-0000",
                     "id": "poseidon.bc4e3796-2d7a-11e4-b8df-d43d7edb01cd",
-                    "name": "poseidon.bc4e3796-2d7a-11e4-b8df-d43d7edb01cd",
+                    "name": "poseidon",
                     "resources": {
                         "cpus": 1,
                         "disk": 0,
@@ -206,6 +206,46 @@
                         "disk": 0,
                         "mem": 1024,
                         "ports": "[31354-31354, 31355-31355]"
+                    },
+                    "slave_id": "20140803-125133-3041283216-5050-2410-0",
+                    "state": "TASK_RUNNING",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1413572371.04321
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20140703-014514-3041283216-5050-5348-0000",
+                    "id": "liquor-store.b71166c1-562f-11e4-a088-c20493233aa5",
+                    "name": "liquor-store",
+                    "resources": {
+                        "cpus": 1,
+                        "disk": 0,
+                        "mem": 1024,
+                        "ports": "[31737-31737]"
+                    },
+                    "slave_id": "20140827-000744-3041283216-5050-2116-1",
+                    "state": "TASK_RUNNING",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1413572383.04559
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20140703-014514-3041283216-5050-5348-0000",
+                    "id": "car-shop.5ae07148-36af-11e5-8a54-0242c0a8215c",
+                    "name": "car-shop",
+                    "resources": {
+                        "cpus": 1,
+                        "disk": 0,
+                        "mem": 1024,
+                        "ports": "[]"
                     },
                     "slave_id": "20140803-125133-3041283216-5050-2410-0",
                     "state": "TASK_RUNNING",
@@ -261,13 +301,13 @@
                 {
                     "executor_id": "",
                     "framework_id": "20140703-014514-3041283216-5050-5348-0000",
-                    "id": "liquor-store.b71166c1-562f-11e4-a088-c20493233aa5",
-                    "name": "liquor-store",
+                    "id": "car-shop.5aeffeb6-36af-11e5-8a54-0242c0a8215c",
+                    "name": "car-shop",
                     "resources": {
                         "cpus": 1,
                         "disk": 0,
                         "mem": 1024,
-                        "ports": "[31737-31737]"
+                        "ports": "[]"
                     },
                     "slave_id": "20140827-000744-3041283216-5050-2116-1",
                     "state": "TASK_RUNNING",
@@ -318,6 +358,32 @@
                         "disk": 0,
                         "mem": 128,
                         "ports": "[31744-31744]"
+                    },
+                    "slave_id": "20140827-000744-3041283216-5050-2116-1",
+                    "state": "TASK_RUNNING",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1414800227.3456,
+                            "labels": [
+                                {
+                                    "key": "foo",
+                                    "value": "bar"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20140703-014514-3041283216-5050-5348-0000",
+                    "id": "proxy.12343434-615a-11e4-a088-c20493233aa5",
+                    "name": "proxy",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 128,
+                        "ports": "[]"
                     },
                     "slave_id": "20140827-000744-3041283216-5050-2116-1",
                     "state": "TASK_RUNNING",

--- a/records/config.go
+++ b/records/config.go
@@ -72,6 +72,9 @@ type Config struct {
 
 	// EnforceRFC952 will enforce an older, more strict set of rules for DNS labels
 	EnforceRFC952 bool
+
+	// Enable serving container IP if the corresponding task status labels are found
+	ContainerIPsOn bool
 }
 
 // SetConfig instantiates a Config struct read in from config.json
@@ -95,6 +98,7 @@ func SetConfig(cjson string) (c Config) {
 		HTTPOn:         true,
 		ExternalOn:     true,
 		RecurseOn:      true,
+		ContainerIPsOn: true,
 	}
 
 	// read configuration file
@@ -179,6 +183,8 @@ func SetConfig(cjson string) (c Config) {
 	logging.Verbose.Println("   - HttpOn: ", c.HTTPOn)
 	logging.Verbose.Println("   - ConfigFile: ", c.File)
 	logging.Verbose.Println("   - EnforceRFC952: ", c.EnforceRFC952)
+	logging.Verbose.Println("   - EnforceRFC952: ", c.EnforceRFC952)
+	logging.Verbose.Println("   - ContainerIPsOn: ", c.ContainerIPsOn)
 
 	return c
 }

--- a/records/generator.go
+++ b/records/generator.go
@@ -242,7 +242,10 @@ func sanitizedSlaveAddress(hostname string, spec labels.HostNameSpec) string {
 }
 
 func (t *Task) containerIP() string {
-	const containerIPTaskStatusLabel = "Docker.NetworkSettings.IPAddress"
+	const (
+		dockerLabel = "Docker.NetworkSettings.IPAddress"
+		mesosLabel = "MesosContainerizer.NetworkSettings.IPAddress"
+	)
 
 	// find TASK_RUNNING statuses
 	var latestContainerIP string
@@ -254,7 +257,7 @@ func (t *Task) containerIP() string {
 
 		// find the latest docker-inspect label
 		for _, label := range status.Labels {
-			if label.Key == containerIPTaskStatusLabel && status.Timestamp > latestTimestamp {
+			if (label.Key == dockerLabel || label.Key == mesosLabel) && status.Timestamp > latestTimestamp {
 				latestContainerIP = label.Value
 				latestTimestamp = status.Timestamp
 				break

--- a/records/generator.go
+++ b/records/generator.go
@@ -244,7 +244,7 @@ func sanitizedSlaveAddress(hostname string, spec labels.HostNameSpec) string {
 func (t *Task) containerIP() string {
 	const (
 		dockerLabel = "Docker.NetworkSettings.IPAddress"
-		mesosLabel = "MesosContainerizer.NetworkSettings.IPAddress"
+		mesosLabel  = "MesosContainerizer.NetworkSettings.IPAddress"
 	)
 
 	// find TASK_RUNNING statuses

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -2,12 +2,12 @@ package records
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
 	"testing/quick"
 
-	"fmt"
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records/labels"
 )

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -272,6 +272,14 @@ func TestInsertState(t *testing.T) {
 		t.Errorf("should return the container IPs 10.3.0.1, 10.3.0.2 for the task, but got %v", rrs)
 	}
 
+	rrs, ok = rg.As["_container.reviewbot.marathon.mesos."]
+	if !ok {
+		t.Error("should find this running task - A record")
+	}
+	if got, want := rrs, []string{"10.5.0.7"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("should return the slave ips 10.5.0.7 for the task, but got %v", rrs)
+	}
+
 	_, ok = rg.As["poseidon.marathon.mesos."]
 	if ok {
 		t.Error("should not find this not-running task - A record")
@@ -308,7 +316,7 @@ func TestInsertState(t *testing.T) {
 	}
 
 	// test for 5 A names
-	if got, want := len(rg.As), 16; got != want {
+	if got, want := len(rg.As), 18; got != want {
 		t.Errorf("not enough As, got %d, expected %d", got, want)
 	}
 

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"testing/quick"
 
+	"fmt"
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records/labels"
 )
@@ -250,95 +251,63 @@ func TestInsertState(t *testing.T) {
 	rg := &RecordGenerator{}
 	rg.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters, spec)
 
-	// ensure we are only collecting running tasks
-	_, ok := rg.SRVs["_poseidon._tcp.marathon.mesos."]
-	if ok {
-		t.Error("should not find this not-running task - SRV record")
+	type expectation struct {
+		domain string
+		num    uint
+		answer []string
+		reason string
+	}
+	expectedARecords := []expectation{
+		{domain: "liquor-store.marathon.mesos.", num: 2, answer: []string{"1.2.3.11", "1.2.3.12"}},
+		{domain: "_container.liquor-store.marathon.mesos.", num: 2, answer: []string{"10.3.0.1", "10.3.0.2"}},
+		{domain: "_container.reviewbot.marathon.mesos.", num: 1, answer: []string{"10.5.0.7"}},
+		{domain: "poseidon.marathon.mesos.", reason: "task was not running"},
+		{domain: "_container.poseidon.marathon.mesos.", reason: "task was not running"},
+		{domain: "master.mesos.", num: 1},
+		{domain: "master0.mesos.", num: 1},
+		{domain: "leader.mesos.", num: 1},
+		{domain: "some-box.chronoswithaspaceandmixe.mesos.", num: 1}, // ensure we translate the framework name as well
+	}
+	expectedSRVRecords := []expectation{
+		{domain: "_poseidon._tcp.marathon.mesos.", reason: "task was not running"},
+		{domain: "_leader._tcp.mesos.", num: 1},
+		{domain: "_liquor-store._tcp.marathon.mesos.", num: 1},
+		{domain: "_liquor-store.marathon.mesos."},
 	}
 
-	rrs, ok := rg.As["liquor-store.marathon.mesos."]
-	if !ok {
-		t.Error("should find this running task - A record")
-	}
-	if got, want := rrs, []string{"1.2.3.11", "1.2.3.12"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("should return the slave ips 1.2.3.11, 1.2.3.12 for the task, but got %v", rrs)
+	checkExpectations := func(expectations []expectation, records rrs, recordName string) {
+		for _, e := range expectations {
+			because := ""
+			if e.reason != "" {
+				because = fmt.Sprintf(", because %s", e.reason)
+			}
+
+			rrs, ok := records[e.domain]
+			if e.num == 0 && ok {
+				s := ""
+				if len(rrs) != 1 {
+					s = "s"
+				}
+
+				t.Errorf(`didn't expect %d %s record%s for "%s"%s. Got %v, expected none.`, len(rrs), recordName, s, e.domain, because, rrs)
+			} else if e.num != 0 && !ok {
+				s := ""
+				if e.num != 1 {
+					s = "s"
+				}
+
+				want := ""
+				if len(e.answer) > 0 {
+					want = fmt.Sprintf(", expected %v", e.answer)
+				}
+
+				t.Errorf(`expected %d %s record%s for "%s"%s. Got %v%s.`, e.num, recordName, s, e.domain, because, rrs, want)
+			}
+		}
 	}
 
-	rrs, ok = rg.As["_container.liquor-store.marathon.mesos."]
-	if !ok {
-		t.Error("should find the container ip")
-	}
-	if got, want := rrs, []string{"10.3.0.1", "10.3.0.2"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("should return the container IPs 10.3.0.1, 10.3.0.2 for the task, but got %v", rrs)
-	}
-
-	rrs, ok = rg.As["_container.reviewbot.marathon.mesos."]
-	if !ok {
-		t.Error("should find this running task - A record")
-	}
-	if got, want := rrs, []string{"10.5.0.7"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("should return the slave ips 10.5.0.7 for the task, but got %v", rrs)
-	}
-
-	_, ok = rg.As["poseidon.marathon.mesos."]
-	if ok {
-		t.Error("should not find this not-running task - A record")
-	}
-
-	_, ok = rg.As["_container.poseidon.marathon.mesos."]
-	if ok {
-		t.Error("should not find a container IP")
-	}
-
-	_, ok = rg.As["master.mesos."]
-	if !ok {
-		t.Error("should find a running master - A record")
-	}
-
-	_, ok = rg.As["master0.mesos."]
-	if !ok {
-		t.Error("should find a running master0 - A record")
-	}
-
-	_, ok = rg.As["leader.mesos."]
-	if !ok {
-		t.Error("should find a leading master - A record")
-	}
-
-	_, ok = rg.SRVs["_leader._tcp.mesos."]
-	if !ok {
-		t.Error("should find a leading master - SRV record")
-	}
-
-	// test for 10 SRV names
-	if got, want := len(rg.SRVs), 10; got != want {
-		t.Errorf("not enough SRVs, got %d, expected %d", got, want)
-	}
-
-	// test for 5 A names
-	if got, want := len(rg.As), 18; got != want {
-		t.Errorf("not enough As, got %d, expected %d", got, want)
-	}
-
-	// ensure we translate the framework name as well
-	_, ok = rg.As["some-box.chronoswithaspaceandmixe.mesos."]
-	if !ok {
-		t.Error("should find this task w/a space in the framework name - A record")
-	}
-
-	// ensure we find this SRV
-	rrs = rg.SRVs["_liquor-store._tcp.marathon.mesos."]
-	// ensure there are 3 RRDATA answers for this SRV name
-	if len(rrs) != 3 {
-		t.Error("not enough SRV records")
-	}
-
-	// ensure we don't find this as a SRV record
-	rrs = rg.SRVs["_liquor-store.marathon.mesos."]
-	if len(rrs) != 0 {
-		t.Error("not a proper SRV record")
-	}
-
+	checkExpectations(expectedARecords, rg.As, "A")
+	checkExpectations(expectedSRVRecords, rg.SRVs, "SRV")
 }
 
 // ensure we only generate one A record for each host

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -246,7 +246,7 @@ func TestInsertState(t *testing.T) {
 	spec := labels.ForRFC952()
 
 	var rg RecordGenerator
-	if err := rg.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters, spec); err != nil {
+	if err := rg.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters, spec, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -256,15 +256,16 @@ func TestInsertState(t *testing.T) {
 		want       []string
 	}{
 		{rg.As, "A", "liquor-store.marathon.mesos.", []string{"1.2.3.11", "1.2.3.12"}},
-		{rg.As, "A", "_container.liquor-store.marathon.mesos.", []string{"10.3.0.1", "10.3.0.2"}},
-		{rg.As, "A", "_container.reviewbot.marathon.mesos.", []string{"10.5.0.7"}},
-		{rg.As, "A", "poseidon.marathon.mesos.", nil},
-		{rg.As, "A", "_container.poseidon.marathon.mesos.", nil},
+		{rg.As, "A", "car-shop.marathon.mesos.", []string{"10.3.0.1", "10.3.0.2"}}, // with container IP
+		{rg.As, "A", "proxy.marathon.mesos.", []string{"10.5.0.7"}}, // with container IP
+		{rg.As, "A", "poseidon.marathon.mesos.", nil}, // b/c it's killed
 		{rg.As, "A", "master.mesos.", []string{"144.76.157.37"}},
 		{rg.As, "A", "master0.mesos.", []string{"144.76.157.37"}},
 		{rg.As, "A", "leader.mesos.", []string{"144.76.157.37"}},
 		{rg.As, "A", "some-box.chronoswithaspaceandmixe.mesos.", []string{"1.2.3.11"}}, // ensure we translate the framework name as well
-		{rg.SRVs, "SRV", "_poseidon._tcp.marathon.mesos.", nil},
+		{rg.SRVs, "SRV", "_car-shop._tcp.marathon.mesos.", nil}, // no SRV b/c of container IP
+		{rg.SRVs, "SRV", "_proxy._tcp.marathon.mesos.", nil}, // no SRV b/c of container IP
+		{rg.SRVs, "SRV", "_poseidon._tcp.marathon.mesos.", nil}, // b/c it's killed
 		{rg.SRVs, "SRV", "_leader._tcp.mesos.", []string{"leader.mesos.:5050"}},
 		{rg.SRVs, "SRV", "_liquor-store._tcp.marathon.mesos.", []string{
 			"liquor-store-17700-0.marathon.mesos.:31354",

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -96,7 +96,7 @@ func fakeDNS(port int) (*Resolver, error) {
 	masters := []string{"144.76.157.37:5050"}
 	spec := labels.ForRFC952()
 	res.rs = &records.RecordGenerator{}
-	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters, spec)
+	res.rs.InsertState(sj, "mesos", "mesos-dns.mesos.", "127.0.0.1", masters, spec, true)
 
 	return res, nil
 }


### PR DESCRIPTION
This PR 
- adds the `MesosContainerizer.NetworkSettings.IPAddress` as alternative label to define container IPs
- and removes the _container prefix

If the container IP is passed via task status label,
- it is returned in the A record instead of the slave IPs
- no SRV records are created for that task (because the container ports are currently not available via state.json).

With DiscoveryInfo support in Mesos-DNS via https://github.com/mesosphere/mesos-dns/pull/147 and corresponding support for container IPs in frameworks like Marathon (it has to put the container ports into the DiscoveryInfo, not the host ports), SRV records can be added again (out of scope of this PR).