### PR TITLE
records: Fallback to framework hostname if PID not present

### DIFF
--- a/factories/fake.json
+++ b/factories/fake.json
@@ -130,6 +130,27 @@
         },
         {
             "active": true,
+            "checkpoint": false,
+            "completed_tasks": [],
+            "failover_timeout": 1200,
+            "hostname": "localhost",
+            "id": "20140703-014514-3041283216-5050-5348-0002",
+            "name": "no pid",
+            "offers": [],
+            "registered_time": 1414913537.10742,
+            "reregistered_time": 1414913537.10744,
+            "resources": {
+                "cpus": 0,
+                 "disk": 0,
+                 "mem": 0
+             },
+             "role": "*",
+             "tasks": [],
+             "unregistered_time": 0,
+             "user": "root"
+        },
+        {
+            "active": true,
             "checkpoint": true,
             "completed_tasks": [
                 {

--- a/records/generator.go
+++ b/records/generator.go
@@ -205,13 +205,14 @@ func (rg *RecordGenerator) InsertState(sj state.State, domain string,
 func (rg *RecordGenerator) frameworkRecords(sj state.State, domain string, spec labels.Func) {
 	for _, f := range sj.Frameworks {
 		fname := labels.DomainFrag(f.Name, labels.Sep, spec)
-
-		// insert framework records (IPv4)
-		if address, ok := hostToIP4(f.PID.Host); ok {
+		host, port := f.HostPort()
+		if address, ok := hostToIP4(host); ok {
 			a := fname + "." + domain + "."
 			rg.insertRR(a, address, "A")
-			srv := net.JoinHostPort(a, f.PID.Port)
-			rg.insertRR("_framework._tcp."+a, srv, "SRV")
+			if port != "" {
+				srv := net.JoinHostPort(a, port)
+				rg.insertRR("_framework._tcp."+a, srv, "SRV")
+			}
 		}
 	}
 }

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -192,6 +192,7 @@ func TestInsertState(t *testing.T) {
 		{rg.As, "A", "slave.mesos.", []string{"1.2.3.10", "1.2.3.11", "1.2.3.12"}},
 		{rg.As, "A", "some-box.chronoswithaspaceandmixe.mesos.", []string{"1.2.3.11"}}, // ensure we translate the framework name as well
 		{rg.As, "A", "marathon.mesos.", []string{"1.2.3.11"}},
+		{rg.As, "A", "nopid.mesos.", []string{"127.0.0.1"}},
 		{rg.SRVs, "SRV", "_poseidon._tcp.marathon.mesos.", nil},
 		{rg.SRVs, "SRV", "_leader._tcp.mesos.", []string{"leader.mesos.:5050"}},
 		{rg.SRVs, "SRV", "_liquor-store._tcp.marathon.mesos.", []string{
@@ -202,6 +203,7 @@ func TestInsertState(t *testing.T) {
 		{rg.SRVs, "SRV", "_liquor-store.marathon.mesos.", nil},
 		{rg.SRVs, "SRV", "_slave._tcp.mesos.", []string{"slave.mesos.:5051"}},
 		{rg.SRVs, "SRV", "_framework._tcp.marathon.mesos.", []string{"marathon.mesos.:25501"}},
+		{rg.SRVs, "SRV", "_framework._tcp.nopid-framework.mesos.", nil},
 	} {
 		if got := tt.rrs[tt.name]; !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("test #%d: %s record for %q: got: %q, want: %q", i, tt.kind, tt.name, got, tt.want)

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -87,9 +87,19 @@ func (t *Task) ContainerIP() string {
 
 // Framework holds a framework as defined in the /state.json Mesos HTTP endpoint.
 type Framework struct {
-	Tasks []Task `json:"tasks"`
-	PID   PID    `json:"pid"`
-	Name  string `json:"name"`
+	Tasks    []Task `json:"tasks"`
+	PID      PID    `json:"pid"`
+	Name     string `json:"name"`
+	Hostname string `json:"hostname"`
+}
+
+// HostPort returns the hostname and port where a framework's scheduler is
+// listening on.
+func (f Framework) HostPort() (string, string) {
+	if f.PID.UPID != nil {
+		return f.PID.Host, f.PID.Port
+	}
+	return f.Hostname, ""
 }
 
 // Slave holds a slave as defined in the /state.json Mesos HTTP endpoint.


### PR DESCRIPTION
Apparently, some Mesos installations don't provide PIDs for frameworks. This patch makes the code fallback to the `hostname` field if not present. In such cases, no SRV records will be generated.

Fixes #127

/cc @lloesche @sttts 