### PR TITLE
Exchanger

### DIFF
--- a/dnstest/doc.go
+++ b/dnstest/doc.go
@@ -1,0 +1,2 @@
+// Package dnstest provides DNS testing utilities and convenience functions.
+package dnstest

--- a/dnstest/message.go
+++ b/dnstest/message.go
@@ -1,0 +1,104 @@
+package dnstest
+
+import (
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// A MsgOpt is functional option for dns.Msgs
+type MsgOpt func(*dns.Msg)
+
+// Message returns a dns.Msg with the given MsgOpts applied to it.
+func Message(opts ...MsgOpt) *dns.Msg {
+	var m dns.Msg
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return &m
+}
+
+// Header returns a MsgOpt that sets a dns.Msg's MsgHdr with the given arguments
+// and some hard-coded defaults.
+func Header(auth bool, rcode int) MsgOpt {
+	return func(m *dns.Msg) {
+		m.Authoritative = auth
+		m.Response = true
+		m.Rcode = rcode
+		m.Compress = true
+	}
+}
+
+// Question returns a MsgOpt that sets the Question section in a Msg.
+func Question(name string, qtype uint16) MsgOpt {
+	return func(m *dns.Msg) { m.SetQuestion(name, qtype) }
+}
+
+// Answers returns a MsgOpt that appends the given dns.RRs to a Msg's Answer
+// section.
+func Answers(rrs ...dns.RR) MsgOpt {
+	return func(m *dns.Msg) { m.Answer = append(m.Answer, rrs...) }
+}
+
+// NSs returns a MsgOpt that appends the given dns.RRs to a Msg's Ns section.
+func NSs(rrs ...dns.RR) MsgOpt {
+	return func(m *dns.Msg) { m.Ns = append(m.Ns, rrs...) }
+}
+
+// Extras returns a MsgOpt that appends the given dns.RRs to a Msg's Extras
+// section.
+func Extras(rrs ...dns.RR) MsgOpt {
+	return func(m *dns.Msg) { m.Extra = append(m.Extra, rrs...) }
+}
+
+// RRHeader returns a dns.RR_Header with the given arguments set as well as a
+// few hard-coded defaults.
+func RRHeader(name string, rrtype uint16, ttl uint32) dns.RR_Header {
+	return dns.RR_Header{
+		Name:   name,
+		Rrtype: rrtype,
+		Class:  dns.ClassINET,
+		Ttl:    ttl,
+	}
+}
+
+// A returns an A record set with the given arguments.
+func A(hdr dns.RR_Header, ip net.IP) *dns.A {
+	return &dns.A{
+		Hdr: hdr,
+		A:   ip.To4(),
+	}
+}
+
+// SRV returns a SRV record set with the given arguments.
+func SRV(hdr dns.RR_Header, target string, port, priority, weight uint16) *dns.SRV {
+	return &dns.SRV{
+		Hdr:      hdr,
+		Target:   target,
+		Port:     port,
+		Priority: priority,
+		Weight:   weight,
+	}
+}
+
+// NS returns a NS record set with the given arguments.
+func NS(hdr dns.RR_Header, ns string) *dns.NS {
+	return &dns.NS{
+		Hdr: hdr,
+		Ns:  ns,
+	}
+}
+
+// SOA returns an SOA records set with the given arguments and some hard-coded
+// defaults.
+func SOA(hdr dns.RR_Header, ns, mbox string, minttl uint32) *dns.SOA {
+	return &dns.SOA{
+		Hdr:     hdr,
+		Ns:      ns,
+		Mbox:    mbox,
+		Minttl:  minttl,
+		Refresh: 60,
+		Retry:   600,
+		Expire:  86400,
+	}
+}

--- a/dnstest/response_recorder.go
+++ b/dnstest/response_recorder.go
@@ -1,0 +1,41 @@
+package dnstest
+
+import (
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// ResponseRecorder implements the dns.ResponseWriter interface. It's used in
+// tests only.
+type ResponseRecorder struct {
+	Local, Remote net.IPAddr
+	Msg           *dns.Msg
+}
+
+// LocalAddr returns the internal Local net.IPAddr.
+func (r ResponseRecorder) LocalAddr() net.Addr { return &r.Local }
+
+// RemoteAddr returns the internal Remote net.IPAddr
+func (r ResponseRecorder) RemoteAddr() net.Addr { return &r.Remote }
+
+// WriteMsg sets the internal Msg to the given Msg and returns nil.
+func (r *ResponseRecorder) WriteMsg(m *dns.Msg) error {
+	r.Msg = m
+	return nil
+}
+
+// Write is not implemented.
+func (r *ResponseRecorder) Write([]byte) (int, error) { return 0, nil }
+
+// Close is not implemented.
+func (r *ResponseRecorder) Close() error { return nil }
+
+// TsigStatus is not implemented.
+func (r ResponseRecorder) TsigStatus() error { return nil }
+
+// TsigTimersOnly is not implemented.
+func (r ResponseRecorder) TsigTimersOnly(bool) {}
+
+// Hijack is not implemented.
+func (r *ResponseRecorder) Hijack() {}

--- a/exchanger/doc.go
+++ b/exchanger/doc.go
@@ -1,0 +1,2 @@
+// Package exchanger provides DNS exchanger decorators and other utilities.
+package exchanger

--- a/exchanger/exchanger.go
+++ b/exchanger/exchanger.go
@@ -1,0 +1,119 @@
+package exchanger
+
+import (
+	"log"
+	"net"
+	"time"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/miekg/dns"
+)
+
+// Exchanger is an interface capturing a dns.Client Exchange method.
+type Exchanger interface {
+	// Exchange performs an synchronous query. It sends the message m to the address
+	// contained in addr (host:port) and waits for a reply.
+	Exchange(m *dns.Msg, addr string) (r *dns.Msg, rtt time.Duration, err error)
+}
+
+// Func is a function type that implements the Exchanger interface.
+type Func func(*dns.Msg, string) (*dns.Msg, time.Duration, error)
+
+// Exchange implements the Exchanger interface.
+func (f Func) Exchange(m *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	return f(m, addr)
+}
+
+// A Decorator adds a layer of behaviour to a given Exchanger.
+type Decorator func(Exchanger) Exchanger
+
+// Decorate decorates an Exchanger with the given Decorators.
+func Decorate(ex Exchanger, ds ...Decorator) Exchanger {
+	decorated := ex
+	for _, decorate := range ds {
+		decorated = decorate(decorated)
+	}
+	return decorated
+}
+
+// Pred is a predicate function type for dns.Msgs.
+type Pred func(*dns.Msg) bool
+
+// While returns an Exchanger which attempts the given Exchangers while the given
+// predicate function returns true for the returned dns.Msg, an error is returned,
+// or all Exchangers are attempted, in which case the return values of the last
+// one are returned.
+func While(p Pred, exs ...Exchanger) Exchanger {
+	return Func(func(m *dns.Msg, a string) (r *dns.Msg, rtt time.Duration, err error) {
+		for _, ex := range exs {
+			if r, rtt, err = ex.Exchange(m, a); err != nil || !p(r) {
+				break
+			}
+		}
+		return
+	})
+}
+
+// ErrorLogging returns a Decorator which logs an Exchanger's errors to the given
+// logger.
+func ErrorLogging(l *log.Logger) Decorator {
+	return func(ex Exchanger) Exchanger {
+		return Func(func(m *dns.Msg, a string) (r *dns.Msg, rtt time.Duration, err error) {
+			defer func() {
+				if err != nil {
+					l.Printf("error exchanging with %q: %v", a, err)
+				}
+			}()
+			return ex.Exchange(m, a)
+		})
+	}
+}
+
+// Instrumentation returns a Decorator which instruments an Exchanger with the given
+// counter.
+func Instrumentation(c logging.Counter) Decorator {
+	return func(ex Exchanger) Exchanger {
+		return Func(func(m *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
+			defer c.Inc()
+			return ex.Exchange(m, a)
+		})
+	}
+}
+
+// A Recurser returns the addr (host:port) of the next DNS server to recurse a
+// Msg to. Empty returns signal that further recursion isn't possible or needed.
+type Recurser func(*dns.Msg) string
+
+// Recurse is the default Mesos-DNS Recurser which returns an addr (host:port)
+// only when the given dns.Msg doesn't contain authoritative answers and has at
+// least one SOA record in its NS section.
+func Recurse(r *dns.Msg) string {
+	if r.Authoritative && len(r.Answer) > 0 {
+		return ""
+	}
+
+	for _, ns := range r.Ns {
+		if soa, ok := ns.(*dns.SOA); ok {
+			return net.JoinHostPort(soa.Ns, "53")
+		}
+	}
+
+	return ""
+}
+
+// Recursion returns a Decorator which recurses until the given Recurser returns
+// an empty string or max attempts have been reached.
+func Recursion(max int, rec Recurser) Decorator {
+	return func(ex Exchanger) Exchanger {
+		return Func(func(m *dns.Msg, a string) (r *dns.Msg, rtt time.Duration, err error) {
+			for i := 0; i <= max; i++ {
+				if r, rtt, err = ex.Exchange(m, a); err != nil {
+					break
+				} else if a = rec(r); a == "" {
+					break
+				}
+			}
+			return r, rtt, err
+		})
+	}
+}

--- a/exchanger/exchanger_test.go
+++ b/exchanger/exchanger_test.go
@@ -1,0 +1,187 @@
+package exchanger
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	. "github.com/mesosphere/mesos-dns/dnstest"
+	"github.com/miekg/dns"
+)
+
+func TestWhile(t *testing.T) {
+	for i, tt := range []struct {
+		pred Pred
+		exs  []Exchanger
+		want exchanged
+	}{
+		{ // error
+			nil,
+			stubs(exchanged{nil, 0, errors.New("foo")}),
+			exchanged{nil, 0, errors.New("foo")},
+		},
+		{ // always true predicate
+			func(*dns.Msg) bool { return true },
+			stubs(exchanged{nil, 0, nil}, exchanged{nil, 1, nil}),
+			exchanged{nil, 1, nil},
+		},
+		{ // nil exchangers
+			nil,
+			nil,
+			exchanged{nil, 0, nil},
+		},
+		{ // empty exchangers
+			nil,
+			stubs(),
+			exchanged{nil, 0, nil},
+		},
+		{ // false predicate
+			func(calls int) Pred {
+				return func(*dns.Msg) bool {
+					calls++
+					return calls != 2
+				}
+			}(0),
+			stubs(exchanged{nil, 0, nil}, exchanged{nil, 1, nil}, exchanged{nil, 2, nil}),
+			exchanged{nil, 1, nil},
+		},
+	} {
+		var got exchanged
+		got.m, got.rtt, got.err = While(tt.pred, tt.exs...).Exchange(nil, "")
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+		}
+	}
+}
+
+func TestRecurse(t *testing.T) {
+	for i, tt := range []struct {
+		*dns.Msg
+		want string
+	}{
+		{ // Authoritative with answers
+			Message(
+				Header(true, 0),
+				Answers(
+					A(RRHeader("localhost", dns.TypeA, 0), net.IPv6loopback.To4()),
+				),
+				NSs(
+					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
+				),
+			),
+			"",
+		},
+		{ // Authoritative, empty answers, no SOA records
+			Message(
+				Header(true, 0),
+				NSs(
+					NS(RRHeader("", dns.TypeNS, 0), "next"),
+				),
+			),
+			"",
+		},
+		{ // Not authoritative, no SOA record
+			Message(Header(false, 0)),
+			"",
+		},
+		{ // Not authoritative, one SOA record
+			Message(
+				Header(false, 0),
+				NSs(SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0)),
+			),
+			"next:53",
+		},
+		{ // Authoritative, empty answers, one SOA record
+			Message(
+				Header(true, 0),
+				NSs(
+					NS(RRHeader("", dns.TypeNS, 0), "foo"),
+					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
+				),
+			),
+			"next:53",
+		},
+	} {
+		if got := Recurse(tt.Msg); got != tt.want {
+			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+		}
+	}
+}
+
+func TestRecursion(t *testing.T) {
+	for i, tt := range []struct {
+		max  int
+		rec  Recurser
+		ex   Exchanger
+		want exchanged
+	}{
+		{
+			0,
+			func(*dns.Msg) string { return "next" },
+			seq(stubs(exchanged{rtt: 1})...),
+			exchanged{rtt: 1},
+		},
+		{
+			1,
+			func(*dns.Msg) string { return "next" },
+			seq(stubs(exchanged{rtt: 0}, exchanged{rtt: 1}, exchanged{rtt: 2})...),
+			exchanged{rtt: 1},
+		},
+		{
+			0,
+			nil,
+			seq(stubs(exchanged{err: errors.New("foo")})...),
+			exchanged{err: errors.New("foo")},
+		},
+		{
+			2,
+			func(calls int) Recurser {
+				return func(*dns.Msg) string {
+					if calls++; calls <= 1 {
+						return "next"
+					}
+					return ""
+				}
+			}(0),
+			seq(stubs(exchanged{rtt: 0}, exchanged{rtt: 1}, exchanged{rtt: 2})...),
+			exchanged{rtt: 1},
+		},
+	} {
+		var got exchanged
+		got.m, got.rtt, got.err = Recursion(tt.max, tt.rec)(tt.ex).Exchange(nil, "")
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+		}
+	}
+}
+
+func seq(exs ...Exchanger) Exchanger {
+	var i int
+	return Func(func(m *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
+		ex := exs[i]
+		i++
+		return ex.Exchange(m, a)
+	})
+}
+
+func stubs(ed ...exchanged) []Exchanger {
+	exs := make([]Exchanger, len(ed))
+	for i := range ed {
+		exs[i] = stub(ed[i])
+	}
+	return exs
+}
+
+func stub(e exchanged) Exchanger {
+	return Func(func(*dns.Msg, string) (*dns.Msg, time.Duration, error) {
+		return e.m, e.rtt, e.err
+	})
+}
+
+type exchanged struct {
+	m   *dns.Msg
+	rtt time.Duration
+	err error
+}


### PR DESCRIPTION
This PR introduces the exchanger package which refactors and tests a lot of the code used in the "external resolver".

Additionally, I extracted testing utilities and convenience functions I had in the `resolver` package to a new `dnstest` package.