### PR TITLE
records, resolver, detect: detect master changes

### DIFF
--- a/detect/masters.go
+++ b/detect/masters.go
@@ -1,0 +1,119 @@
+package detect
+
+import (
+	"encoding/binary"
+	"net"
+	"strconv"
+
+	"github.com/mesos/mesos-go/detector"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+
+	"github.com/mesosphere/mesos-dns/logging"
+)
+
+var (
+	_ detector.MasterChanged = (*Masters)(nil)
+	_ detector.AllMasters    = (*Masters)(nil)
+)
+
+// Masters detects changes of leader and/or master elections
+// and sends these changes to a channel.
+type Masters struct {
+	// current masters list,
+	// 1st item represents the leader,
+	// the rest remaining masters
+	masters []string
+
+	// the channel leader/master changes are being sent to
+	changed chan<- []string
+}
+
+// NewMasters returns a new Masters detector with the given initial masters
+// and the given changed channel to which master changes will be sent to.
+// Initially the leader is unknown which is represented by
+// setting the first item of the sent masters slice to be empty.
+func NewMasters(masters []string, changed chan<- []string) *Masters {
+	return &Masters{
+		masters: append([]string{""}, masters...),
+		changed: changed,
+	}
+}
+
+// OnMasterChanged sets the given MasterInfo as the current leader
+// leaving the remaining masters unchanged and emits the current masters state.
+// It implements the detector.MasterChanged interface.
+func (ms *Masters) OnMasterChanged(leader *mesos.MasterInfo) {
+	logging.VeryVerbose.Println("Updated leader: ", leader)
+
+	if leader == nil {
+		logging.Error.Println("No master available in Zookeeper.")
+		return
+	}
+
+	ms.masters = ordered(masterHostPort(leader), ms.masters[1:])
+	emit(ms.changed, ms.masters)
+}
+
+// UpdatedMasters sets the given slice of MasterInfo as the current remaining masters
+// leaving the current leader unchanged and emits the current masters state.
+// It implements the detector.AllMasters interface.
+func (ms *Masters) UpdatedMasters(infos []*mesos.MasterInfo) {
+	logging.VeryVerbose.Println("Updated masters: ", infos)
+
+	if infos == nil {
+		logging.Error.Println("No masters available in Zookeeper.")
+		return
+	}
+
+	masters := make([]string, 0, len(infos))
+	for _, info := range infos {
+		if validMasterInfo(info) {
+			masters = append(masters, masterHostPort(info))
+		}
+	}
+
+	if len(masters) == 0 {
+		logging.Error.Println("No valid masters available in Zookeeper.")
+		return
+	}
+
+	ms.masters = ordered(ms.masters[0], masters)
+	emit(ms.changed, ms.masters)
+}
+
+func emit(ch chan<- []string, s []string) {
+	ch <- append(make([]string, 0, len(s)), s...)
+}
+
+// ordered returns a slice of masters with the given leader in the first position
+func ordered(leader string, masters []string) []string {
+	ms := append(make([]string, 0, len(masters)+1), leader)
+	for _, m := range masters {
+		if m != leader {
+			ms = append(ms, m)
+		}
+	}
+	return ms
+}
+
+func validMasterInfo(info *mesos.MasterInfo) bool {
+	return info.GetHostname() != "" || info.GetIp() != 0
+}
+
+func masterHostPort(info *mesos.MasterInfo) string {
+	host := info.GetHostname()
+
+	if host == "" {
+		// unpack IPv4
+		octets := make([]byte, 4)
+		binary.BigEndian.PutUint32(octets, info.GetIp())
+		ipv4 := net.IP(octets)
+		host = ipv4.String()
+	}
+
+	return net.JoinHostPort(host, masterPort(info))
+}
+
+func masterPort(info *mesos.MasterInfo) string {
+	return strconv.FormatUint(uint64(info.GetPort()), 10)
+}

--- a/detect/masters_test.go
+++ b/detect/masters_test.go
@@ -1,0 +1,133 @@
+package detect
+
+import (
+	"reflect"
+	"testing"
+
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	"github.com/mesosphere/mesos-dns/logging"
+)
+
+func TestMasters_UpdatedMasters(t *testing.T) {
+	// create a new masters detector with an unknown leader and no masters
+	ch := make(chan []string, 1)
+	m := NewMasters([]string{}, ch)
+
+	for i, tt := range []struct {
+		masters []*mesos.MasterInfo
+		want    []string
+	}{
+		{
+			// update a single master
+			// leave the unknown leader "" unchanged
+			newMasterInfos([]string{"a"}),
+			[]string{"", "a:5050"},
+		},
+		{
+			// update additional masters,
+			// expect them to be appended with the default port number,
+			// leave the unknown leader "" unchanged
+			newMasterInfos([]string{"b", "c", "d"}),
+			[]string{"", "b:5050", "c:5050", "d:5050"},
+		},
+		{
+			// update additional masters with an empty slice
+			// expect no update at all (nil)
+			newMasterInfos([]string{}),
+			nil,
+		},
+		{
+			// update masters with a niladic value
+			// expect no update at all (nil)
+			nil,
+			nil,
+		},
+	} {
+		m.UpdatedMasters(tt.masters)
+
+		if got := recv(ch); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test #%d: got %v, want: %v", i, got, tt.want)
+		}
+	}
+}
+
+func TestMasters_OnMasterChanged(t *testing.T) {
+	// create a new masters detector with an unknown leader
+	// and two initial masters "a:5050", "b:5050"
+	ch := make(chan []string, 1)
+	m := NewMasters([]string{"a:5050", "b:5050"}, ch)
+
+	for i, tt := range []struct {
+		leader *mesos.MasterInfo
+		want   []string
+	}{
+		{
+			// update new leader "a",
+			// expect an appended port number
+			// leaving "b:5050" as the only additional master
+			newMasterInfo("a"),
+			[]string{"a:5050", "b:5050"},
+		},
+		{
+			// update new leader "c"
+			// replacing "a:5050"
+			newMasterInfo("c"),
+			[]string{"c:5050", "b:5050"},
+		},
+		{
+			// update new leader "b"
+			// replacing "c"
+			newMasterInfo("b"),
+			[]string{"b:5050"},
+		},
+		{
+			// update new leader "", the hostname being the empty string
+			// expect to fallback to its ip address,
+			// being 0 by default, implying "0.0.0.0"
+			newMasterInfo(""),
+			[]string{"0.0.0.0:5050"},
+		},
+		{
+			// update new leader with a niladic value
+			// expect no update at all (nil)
+			nil,
+			nil,
+		},
+	} {
+		m.OnMasterChanged(tt.leader)
+
+		if got := recv(ch); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test #%d: got %v, want: %v", i, got, tt.want)
+		}
+	}
+}
+
+// recv receives from a channel in a non-blocking way, returning the received value or nil.
+func recv(ch <-chan []string) []string {
+	select {
+	case val := <-ch:
+		return val
+	default:
+		return nil
+	}
+}
+
+func newMasterInfo(hostname string) *mesos.MasterInfo {
+	return &mesos.MasterInfo{Hostname: &hostname}
+}
+
+func newMasterInfos(hostnames []string) []*mesos.MasterInfo {
+	ms := make([]*mesos.MasterInfo, len(hostnames))
+
+	for i, h := range hostnames {
+		ms[i] = newMasterInfo(h)
+	}
+
+	return ms
+}
+
+func init() {
+	// TODO(tsenart): Refactor the logging package
+	logging.VerboseFlag = true
+	logging.SetupLogs()
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
+	"github.com/mesos/mesos-go/detector"
+	"github.com/mesosphere/mesos-dns/detect"
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/resolver"
@@ -40,59 +43,47 @@ func main() {
 
 	// initialize resolver
 	config := records.SetConfig(*cjson)
-	resolver := resolver.New(version, config)
+	res := resolver.New(version, config)
 	errch := make(chan error)
 
 	// launch DNS server
 	if config.DNSOn {
-		go func() { errch <- <-resolver.LaunchDNS() }()
+		go func() { errch <- <-res.LaunchDNS() }()
 	}
 
 	// launch HTTP server
 	if config.HTTPOn {
-		go func() { errch <- <-resolver.LaunchHTTP() }()
+		go func() { errch <- <-res.LaunchHTTP() }()
 	}
 
-	var newLeader <-chan struct{}
-	var zkErr <-chan error
-	// launch Zookeeper listener
+	changed := make(chan []string, 1)
 	if config.Zk != "" {
-		newLeader, zkErr = resolver.LaunchZK(zkInitialDetectionTimeout)
-		go func() { errch <- <-zkErr }()
+		logging.Verbose.Println("Starting master detector for ZK ", config.Zk)
+		if md, err := detector.New(config.Zk); err != nil {
+			log.Fatalf("failed to create master detector: %v", err)
+		} else if err := md.Detect(detect.NewMasters(config.Masters, changed)); err != nil {
+			log.Fatalf("failed to initialize master detector: %v", err)
+		}
 	} else {
-		// uniform behavior when new leader from masters field
-		leader := make(chan struct{}, 1)
-		leader <- struct{}{}
-		newLeader = leader
+		changed <- config.Masters
 	}
 
-	// generate reload signal; up to 1 reload pending at any time
-	reloadSignal := make(chan struct{}, 1)
-	tryReload := func() {
-		// non-blocking, attempt to queue a reload
-		select {
-		case reloadSignal <- struct{}{}:
-		default:
-		}
-	}
+	reload := time.NewTicker(time.Second * time.Duration(config.RefreshSeconds))
+	timeout := time.AfterFunc(zkInitialDetectionTimeout, func() {
+		errch <- fmt.Errorf("master detection timed out after %s", zkInitialDetectionTimeout)
+	})
 
-	// periodic loading of DNS state (pull from Master)
-	go func() {
-		defer util.HandleCrash()
-		reloadTimeout := time.Second * time.Duration(config.RefreshSeconds)
-		reloadTimer := time.AfterFunc(reloadTimeout, tryReload)
-		for _ = range reloadSignal {
-			resolver.Reload()
-			logging.PrintCurLog()
-			reloadTimer.Reset(reloadTimeout)
-		}
-	}()
-
-	// infinite loop until there is fatal error
+	defer reload.Stop()
+	defer util.HandleCrash()
 	for {
 		select {
-		case <-newLeader:
-			tryReload()
+		case <-reload.C:
+			res.Reload()
+		case masters := <-changed:
+			timeout.Stop()
+			logging.VeryVerbose.Printf("new masters detected: %v", masters)
+			res.SetMasters(masters)
+			res.Reload()
 		case err := <-errch:
 			logging.Error.Fatal(err)
 		}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -273,56 +272,6 @@ func TestHTTP(t *testing.T) {
 		} else {
 			_ = resp.Body.Close()
 		}
-	}
-}
-
-func TestLaunchZK(t *testing.T) {
-	var closeOnce sync.Once
-	ch := make(chan struct{})
-	closer := func() { closeOnce.Do(func() { close(ch) }) }
-	res := &Resolver{
-		startZKdetection: func(zkurl string, leaderChanged func(string)) error {
-			go func() {
-				defer closer()
-				leaderChanged("")
-				leaderChanged("")
-				leaderChanged("a")
-				leaderChanged("")
-				leaderChanged("")
-				leaderChanged("b")
-				leaderChanged("")
-				leaderChanged("")
-				leaderChanged("c")
-			}()
-			return nil
-		},
-	}
-	leaderSig, errCh := res.LaunchZK(1 * time.Second)
-	onError(ch, errCh, func(err error) { t.Fatalf("unexpected error: %v", err) })
-	getLeader := func() string {
-		res.leaderLock.Lock()
-		defer res.leaderLock.Unlock()
-		return res.leader
-	}
-	for i := 0; i < 3; i++ {
-		select {
-		case <-leaderSig:
-			t.Logf("new leader %d: %s", i, getLeader())
-		case <-time.After(1 * time.Second):
-			t.Fatalf("timed out waiting for new leader")
-		}
-	}
-	select {
-	case <-ch:
-	case <-time.After(1 * time.Second):
-		t.Fatalf("timed out waiting for detector death")
-	}
-	// there should be nothing left in the leader signal chan
-	select {
-	case <-leaderSig:
-		t.Fatalf("unexpected new leader")
-	case <-time.After(200 * time.Millisecond):
-		// expected
 	}
 }
 


### PR DESCRIPTION
This PR fixes #166 and replaces https://github.com/mesosphere/mesos-dns/pull/241

Previously mesos masters were never being updated once configured. This
change implements the update of mesos masters if the active detector
plugin supports this operation.

To propagate leader/masters changes locks were being used. This commit
also replaces the lock-based propagation (communicate by sharing)
with a channel communication (share by communicating).

Additionally launching zookeeper detection is decoupled from the
resolver.