### PR TITLE
Allow hostnames for delegate resolvers

### DIFF
--- a/records/validation.go
+++ b/records/validation.go
@@ -25,31 +25,27 @@ func validateMasters(ms []string) error {
 		}
 		//TODO(jdef) distinguish between intended hostnames and invalid ip addresses
 		if _, found := valid[m]; found {
-			return fmt.Errorf("duplicate master specified: %v", ms[i])
+			return fmt.Errorf("duplicate master specified: %q", ms[i])
 		}
 		valid[m] = struct{}{}
 	}
 	return nil
 }
 
-// validateResolvers checks that each resolver in the list is a properly formatted IP address.
-// duplicate resolvers in the list are not allowed.
-// returns nil if the resolver list is empty, or else all resolvers in the list are valid.
+// validateResolvers errors if there are duplicate resolvers, otherwise returns nil.
 func validateResolvers(rs []string) error {
 	if len(rs) == 0 {
 		return nil
 	}
 	ips := make(map[string]struct{}, len(rs))
 	for _, r := range rs {
-		ip := net.ParseIP(r)
-		if ip == nil {
-			return fmt.Errorf("illegal IP specified for resolver %q", r)
+		if r == "" {
+			return fmt.Errorf("empty resolver IP specified: %q", r)
 		}
-		ipstr := ip.String()
-		if _, found := ips[ipstr]; found {
-			return fmt.Errorf("duplicate resolver IP specified: %v", r)
+		if _, found := ips[r]; found {
+			return fmt.Errorf("duplicate resolver IP specified: %q", r)
 		}
-		ips[ipstr] = struct{}{}
+		ips[r] = struct{}{}
 	}
 	return nil
 }

--- a/records/validation.go
+++ b/records/validation.go
@@ -11,9 +11,9 @@ const hostnamePattern = `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)
 
 var hostnameRegexp *regexp.Regexp
 
-// validateMasters checks that each master in the list is a properly formatted host:ip pair.
-// duplicate masters in the list are not allowed.
-// returns nil if the masters list is empty, or else all masters in the list are valid.
+// validateMasters checks that each element in the list is valid.
+// List elements must be either a valid IP:port or a valid hostname:port.
+// List must not contain duplicates (after IPv6 normalization).
 func validateMasters(ms []string) error {
 	if len(ms) == 0 {
 		return nil
@@ -38,7 +38,9 @@ func validateMasters(ms []string) error {
 	return nil
 }
 
-// validateResolvers errors if there are duplicate resolvers, otherwise returns nil.
+// validateResolvers checks that each element in the list is valid.
+// List elements must be either a valid IP or a valid hostname.
+// List must not contain duplicates (after IPv6 normalization).
 func validateResolvers(rs []string) error {
 	if len(rs) == 0 {
 		return nil

--- a/records/validation_test.go
+++ b/records/validation_test.go
@@ -10,10 +10,11 @@ func TestValidateMasters(t *testing.T) {
 		{[]string{}, true},
 		{[]string{""}, false},
 		{[]string{"", ""}, false},
-		{[]string{"a"}, false},
-		{[]string{"a:1234"}, true},
-		{[]string{"a", "b"}, false},
-		{[]string{"a:1", "b:1"}, true},
+		{[]string{"localhost"}, false},
+		{[]string{"localhost:1234"}, true},
+		{[]string{"example.com"}, false},
+		{[]string{"example.com:1234"}, true},
+		{[]string{"example.com:1234", "localhost:1234"}, true},
 		{[]string{"1.2.3.4"}, false},
 		{[]string{"1.2.3.4:5"}, true},
 		{[]string{"1.2.3.4.5"}, false},
@@ -21,6 +22,7 @@ func TestValidateMasters(t *testing.T) {
 		{[]string{"1.2.3.4", "1.2.3.4"}, false},
 		{[]string{"1.2.3.4:1", "1.2.3.4:1"}, false},
 		{[]string{"1.2.3.4:1", "5.6.7.8:1"}, true},
+		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"}, false},
 		{[]string{"[2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b]:1"}, true},
 		{[]string{"[2001:db8:3c4d:15::1a2f:1a2b]:1"}, true},
 		{[]string{"[2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b]:1", "[2001:db8:3c4d:15::1a2f:1a2b]:1"}, false},
@@ -35,15 +37,17 @@ func TestValidateResolvers(t *testing.T) {
 		{[]string{}, true},
 		{[]string{""}, false},
 		{[]string{"", ""}, false},
-		{[]string{"a"}, false},
-		{[]string{"a", "b"}, false},
+		{[]string{"localhost"}, true},
+		{[]string{"example.com"}, true},
+		{[]string{"example.com", "localhost"}, true},
+		{[]string{"localhost", "localhost"}, false},
 		{[]string{"1.2.3.4"}, true},
-		{[]string{"1.2.3.4.5"}, false},
+//		{[]string{"1.2.3.4.5"}, false},
 		{[]string{"1.2.3.4", "1.2.3.4"}, false},
 		{[]string{"1.2.3.4", "5.6.7.8"}, true},
 		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"}, true},
 		{[]string{"2001:db8:3c4d:15::1a2f:1a2b"}, true},
-		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
+//		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
 	} {
 		validate(t, i+1, tc, validateResolvers)
 	}
@@ -59,8 +63,8 @@ func validate(t *testing.T, i int, tc validationTest, f func([]string) error) {
 	case (err == nil && tc.valid) || (err != nil && !tc.valid):
 		return // valid
 	case tc.valid:
-		t.Fatalf("test %d failed, unexpected error validating resolvers %v: %v", i, tc.in, err)
+		t.Fatalf("test %d failed, unexpected error validating resolvers %q: %v", i, tc.in, err)
 	default:
-		t.Fatalf("test %d failed, expected validation error for resolvers(%d) %v", i, len(tc.in), tc.in)
+		t.Fatalf("test %d failed, expected validation error for resolvers %#v", i, tc.in)
 	}
 }

--- a/records/validation_test.go
+++ b/records/validation_test.go
@@ -18,7 +18,8 @@ func TestValidateMasters(t *testing.T) {
 		{[]string{"1.2.3.4"}, false},
 		{[]string{"1.2.3.4:5"}, true},
 		{[]string{"1.2.3.4.5"}, false},
-		{[]string{"1.2.3.4.5:6"}, true}, // no validation of hostnames
+		{[]string{"1.2.3.4.5:6"}, false}, // TLD must not be all digits
+		{[]string{"1.2.3.4.5x:6"}, true}, // custom TLD may start with a digit
 		{[]string{"1.2.3.4", "1.2.3.4"}, false},
 		{[]string{"1.2.3.4:1", "1.2.3.4:1"}, false},
 		{[]string{"1.2.3.4:1", "5.6.7.8:1"}, true},
@@ -42,12 +43,13 @@ func TestValidateResolvers(t *testing.T) {
 		{[]string{"example.com", "localhost"}, true},
 		{[]string{"localhost", "localhost"}, false},
 		{[]string{"1.2.3.4"}, true},
-//		{[]string{"1.2.3.4.5"}, false},
+		{[]string{"1.2.3.4.5"}, false}, // TLD must not be all digits
+		{[]string{"1.2.3.4.5x"}, true}, // TLD may start with a digit
 		{[]string{"1.2.3.4", "1.2.3.4"}, false},
 		{[]string{"1.2.3.4", "5.6.7.8"}, true},
 		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"}, true},
 		{[]string{"2001:db8:3c4d:15::1a2f:1a2b"}, true},
-//		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
+		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
 	} {
 		validate(t, i+1, tc, validateResolvers)
 	}


### PR DESCRIPTION
### Use Case

As a deployment operator, I want to be able to chain DNS together with hostnames (not just IPs).

Note: masters can already be specified by host or domain name.
### Example Usage

Because deployments may contain more than just Mesos (e.g. Marathon), another DNS may be required that can resolve non-Mesos machines. In order to resolve Mesos, non-Mesos cluster machines, and internet domains, three DNS must be chained together. 

Example chain: `mesosdns` > `dnsdock` > `8.8.8.8`. 

Because Mesos-DNS depends on both zookeeper and mesos-master, it may not be ready as soon as the DNS it delegates to. So all three DNS need to be configured for each machine in the above chain, as well as for the DNS themselves.
#### Example docker-compose fragment

```
dnsdock:
  hostname: dnsdock
  image: tonistiigi/dnsdock
  command: [ "-nameserver=8.8.8.8" ]
  environment:
  - DNSDOCK_NAME=dnsdock
  - DNSDOCK_IMAGE=mesos
  volumes:
  - /var/run/docker.sock:/run/docker.sock
  dns:
  - 127.0.0.1
  - 8.8.8.8
mesosmaster1:
  hostname: master1.mesos.docker
  image: mesosphere/mesos:0.23.0-1.0.ubuntu1404
  entrypoint: [ "mesos-master" ]
  environment:
  - DNSDOCK_NAME=master1
  - DNSDOCK_IMAGE=mesos
  dns:
  - mesosdns.mesos.docker
  - dnsdock
  - 8.8.8.8
mesosdns:
  hostname: mesosdns.mesos.docker
  image: mesosphere/mesos-dns
  command: [ "/usr/bin/mesos-dns", "-v=2", "-config=/config.json" ]
  environment:
  - DNSDOCK_NAME=mesosdns
  - DNSDOCK_IMAGE=mesos
  volumes:
  - /var/tmp/config.json:/config.json
  links:
  - dnsdock
  - mesosmaster1
  dns:
  - localhost
  - dnsdock
  - 8.8.8.8
```
#### Example Mesos-DNS fragment

```
{
  "zk": "zk://zookeeper:2181/mesos",
  "masters": ["mesosmaster1:5050"],
  "domain": "mesos",
  "resolvers": ["dnsdock"],
}
```
