### PR TITLE
add netinfo to validateIPSources config validation

### DIFF
--- a/records/config_test.go
+++ b/records/config_test.go
@@ -14,3 +14,12 @@ func TestNonLocalAddies(t *testing.T) {
 		}
 	}
 }
+
+func TestNewConfigValidates(t *testing.T) {
+	c := NewConfig()
+	err := validateIPSources(c.IPSources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//TODO(jdef) add other validators here..
+}

--- a/records/validation.go
+++ b/records/validation.go
@@ -62,8 +62,6 @@ func validateIPSources(srcs []string) error {
 	if len(srcs) != len(unique(srcs)) {
 		return fmt.Errorf("duplicate ip source specified")
 	}
-	//TODO(jdef) we need a unit test that (minimally) validates that the default config options
-	// pass validation
 	for _, src := range srcs {
 		switch src {
 		case "host", "docker", "mesos", "netinfo":

--- a/records/validation.go
+++ b/records/validation.go
@@ -62,9 +62,11 @@ func validateIPSources(srcs []string) error {
 	if len(srcs) != len(unique(srcs)) {
 		return fmt.Errorf("duplicate ip source specified")
 	}
+	//TODO(jdef) we need a unit test that (minimally) validates that the default config options
+	// pass validation
 	for _, src := range srcs {
 		switch src {
-		case "host", "docker", "mesos":
+		case "host", "docker", "mesos", "netinfo":
 		default:
 			return fmt.Errorf("invalid ip source %q", src)
 		}


### PR DESCRIPTION
without this, mesos-dns does not start with default config options

/cc @tsenart @nqn @ConnorDoyle 