### PR TITLE
unit test should validate default config settings

### DIFF
--- a/records/config.go
+++ b/records/config.go
@@ -114,11 +114,9 @@ func SetConfig(cjson string) Config {
 		logging.Error.Fatal(err)
 	}
 	// validate and complete configuration file
-	if !c.DNSOn && !c.HTTPOn {
-		logging.Error.Fatalf("Either DNS or HTTP server should be on")
-	}
-	if len(c.Masters) == 0 && c.Zk == "" {
-		logging.Error.Fatalf("specify mesos masters or zookeeper in config.json")
+	err = validateEnabledServices(c)
+	if err != nil {
+		logging.Error.Fatalf("service validation failed: %v", err)
 	}
 	if err = validateMasters(c.Masters); err != nil {
 		logging.Error.Fatalf("Masters validation failed: %v", err)

--- a/records/config_test.go
+++ b/records/config_test.go
@@ -19,23 +19,23 @@ func TestNewConfigValidates(t *testing.T) {
 	c := NewConfig()
 	err := validateIPSources(c.IPSources)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	err = validateResolvers(c.Resolvers)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	err = validateMasters(c.Masters)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	err = validateEnabledServices(&c)
 	if err == nil {
-		t.Fatal("expected error because no masters and no zk servers are configured by default")
+		t.Error("expected error because no masters and no zk servers are configured by default")
 	}
 	c.Zk = "foo"
 	err = validateEnabledServices(&c)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }

--- a/records/config_test.go
+++ b/records/config_test.go
@@ -29,4 +29,13 @@ func TestNewConfigValidates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = validateEnabledServices(&c)
+	if err == nil {
+		t.Fatal("expected error because no masters and no zk servers are configured by default")
+	}
+	c.Zk = "foo"
+	err = validateEnabledServices(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/records/config_test.go
+++ b/records/config_test.go
@@ -21,5 +21,12 @@ func TestNewConfigValidates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//TODO(jdef) add other validators here..
+	err = validateResolvers(c.Resolvers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateMasters(c.Masters)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/records/validation.go
+++ b/records/validation.go
@@ -5,6 +5,16 @@ import (
 	"net"
 )
 
+func validateEnabledServices(c *Config) error {
+	if !c.DNSOn && !c.HTTPOn {
+		return fmt.Errorf("Either DNS or HTTP server should be on")
+	}
+	if len(c.Masters) == 0 && c.Zk == "" {
+		return fmt.Errorf("specify mesos masters or zookeeper in config.json")
+	}
+	return nil
+}
+
 // validateMasters checks that each master in the list is a properly formatted host:ip pair.
 // duplicate masters in the list are not allowed.
 // returns nil if the masters list is empty, or else all masters in the list are valid.


### PR DESCRIPTION
- fixes #269, expand default configuration unit test to:
  - validate default resolvers
  - validate default masters
  - validate default http/dns/zk-detector settings