### PR TITLE
exchanger: Fix Recurse logic

### DIFF
--- a/exchanger/exchanger.go
+++ b/exchanger/exchanger.go
@@ -85,10 +85,10 @@ func Instrumentation(c logging.Counter) Decorator {
 type Recurser func(*dns.Msg) string
 
 // Recurse is the default Mesos-DNS Recurser which returns an addr (host:port)
-// only when the given dns.Msg doesn't contain authoritative answers and has at
-// least one SOA record in its NS section.
+// only when the given dns.Msg doesn't doesn't contain answers or isn't
+// authoritative and has at least one SOA record in its NS section.
 func Recurse(r *dns.Msg) string {
-	if r.Authoritative && len(r.Answer) > 0 {
+	if r.Authoritative || len(r.Answer) > 0 {
 		return ""
 	}
 

--- a/exchanger/exchanger_test.go
+++ b/exchanger/exchanger_test.go
@@ -61,45 +61,32 @@ func TestRecurse(t *testing.T) {
 		*dns.Msg
 		want string
 	}{
-		{ // Authoritative with answers
+		{ // Authoritative, no answers
+			Message(Header(true, 0)),
+			"",
+		},
+		{ // Authoritative, with answers
 			Message(
 				Header(true, 0),
-				Answers(
-					A(RRHeader("localhost", dns.TypeA, 0), net.IPv6loopback.To4()),
-				),
-				NSs(
-					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
-				),
+				Answers(A(RRHeader("localhost", dns.TypeA, 0), net.IPv6loopback.To4())),
 			),
 			"",
 		},
-		{ // Authoritative, empty answers, no SOA records
+		{ // Not authoritative, with answers
 			Message(
-				Header(true, 0),
-				NSs(
-					NS(RRHeader("", dns.TypeNS, 0), "next"),
-				),
+				Header(false, 0),
+				Answers(A(RRHeader("localhost", dns.TypeA, 0), net.IPv6loopback.To4())),
 			),
 			"",
 		},
-		{ // Not authoritative, no SOA record
+		{ // Not authoritative, no answers, no SOA record
 			Message(Header(false, 0)),
 			"",
 		},
-		{ // Not authoritative, one SOA record
+		{ // Not authoritative, no answers, one SOA record
 			Message(
 				Header(false, 0),
 				NSs(SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0)),
-			),
-			"next:53",
-		},
-		{ // Authoritative, empty answers, one SOA record
-			Message(
-				Header(true, 0),
-				NSs(
-					NS(RRHeader("", dns.TypeNS, 0), "foo"),
-					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
-				),
 			),
 			"next:53",
 		},


### PR DESCRIPTION
This commit fixes a logic bug introduced with the refactoring of the external
resolver code: https://github.com/mesosphere/mesos-dns/commit/31f5539

The bug manifested when external queries would be sent to configured resolvers
that would reply with non-authoritative answers. These answers weren't
considered valid and if the message would contain an SOA record in its
authoritative section then it would be erroneously recursed.