### PR TITLE
Prevent exit on ZK detection timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,11 +66,6 @@ func main() {
 
 	reload := time.NewTicker(time.Second * time.Duration(config.RefreshSeconds))
 
-	zkTimeout := time.Second * time.Duration(config.ZkDetectionTimeout)
-	timeout := time.AfterFunc(zkTimeout, func() {
-		errch <- fmt.Errorf("master detection timed out after %s", zkTimeout)
-	})
-
 	defer reload.Stop()
 	defer util.HandleCrash()
 	for {
@@ -78,7 +73,6 @@ func main() {
 		case <-reload.C:
 			res.Reload()
 		case masters := <-changed:
-			timeout.Stop()
 			logging.VeryVerbose.Printf("new masters detected: %v", masters)
 			res.SetMasters(masters)
 			res.Reload()

--- a/records/config.go
+++ b/records/config.go
@@ -23,8 +23,6 @@ type Config struct {
 	// Timeout is the default connect/read/write timeout for outbound
 	// queries
 	Timeout int
-	// Zookeeper Detection Timeout: how long in seconds to wait for Zookeeper to be initially responsive (default 30)
-	ZkDetectionTimeout int
 	// NOTE(tsenart): HTTPPort, DNSOn and HTTPOn have defined JSON keys for
 	// backwards compatibility with external API clients.
 	HTTPPort int `json:"HttpPort"`
@@ -66,26 +64,25 @@ type Config struct {
 // NewConfig return the default config of the resolver
 func NewConfig() Config {
 	return Config{
-		ZkDetectionTimeout: 30,
-		RefreshSeconds:     60,
-		TTL:                60,
-		Domain:             "mesos",
-		Port:               53,
-		Timeout:            5,
-		SOARname:           "root.ns1.mesos",
-		SOAMname:           "ns1.mesos",
-		SOARefresh:         60,
-		SOARetry:           600,
-		SOAExpire:          86400,
-		SOAMinttl:          60,
-		Resolvers:          []string{"8.8.8.8"},
-		Listener:           "0.0.0.0",
-		HTTPPort:           8123,
-		DNSOn:              true,
-		HTTPOn:             true,
-		ExternalOn:         true,
-		RecurseOn:          true,
-		IPSources:          []string{"netinfo", "mesos", "host"},
+		RefreshSeconds: 60,
+		TTL:            60,
+		Domain:         "mesos",
+		Port:           53,
+		Timeout:        5,
+		SOARname:       "root.ns1.mesos",
+		SOAMname:       "ns1.mesos",
+		SOARefresh:     60,
+		SOARetry:       600,
+		SOAExpire:      86400,
+		SOAMinttl:      60,
+		Resolvers:      []string{"8.8.8.8"},
+		Listener:       "0.0.0.0",
+		HTTPPort:       8123,
+		DNSOn:          true,
+		HTTPOn:         true,
+		ExternalOn:     true,
+		RecurseOn:      true,
+		IPSources:      []string{"netinfo", "mesos", "host"},
 	}
 }
 
@@ -129,7 +126,6 @@ func SetConfig(cjson string) Config {
 	logging.Verbose.Println("Mesos-DNS configuration:")
 	logging.Verbose.Println("   - Masters: " + strings.Join(c.Masters, ", "))
 	logging.Verbose.Println("   - Zookeeper: ", c.Zk)
-	logging.Verbose.Println("   - ZookeeperDetectionTimeout: ", c.ZkDetectionTimeout)
 	logging.Verbose.Println("   - RefreshSeconds: ", c.RefreshSeconds)
 	logging.Verbose.Println("   - Domain: " + c.Domain)
 	logging.Verbose.Println("   - Listener: " + c.Listener)


### PR DESCRIPTION
Addresses: #284 

This one line fix will do it. There are other instances where mesos-dns could fail fatally due to dependent libraries but thats outside the scope of this fix. 