### PR TITLE
Transparent proxying of external queries

### DIFF
--- a/exchanger/exchanger_test.go
+++ b/exchanger/exchanger_test.go
@@ -1,169 +1,63 @@
 package exchanger
 
 import (
+	"bytes"
 	"errors"
-	"net"
-	"reflect"
+	"log"
 	"testing"
 	"time"
 
-	. "github.com/mesosphere/mesos-dns/dnstest"
+	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/miekg/dns"
 )
 
-func TestWhile(t *testing.T) {
-	for i, tt := range []struct {
-		pred Pred
-		exs  []Exchanger
-		want exchanged
-	}{
-		{ // error
-			nil,
-			stubs(exchanged{nil, 0, errors.New("foo")}),
-			exchanged{nil, 0, errors.New("foo")},
-		},
-		{ // always true predicate
-			func(*dns.Msg) bool { return true },
-			stubs(exchanged{nil, 0, nil}, exchanged{nil, 1, nil}),
-			exchanged{nil, 1, nil},
-		},
-		{ // nil exchangers
-			nil,
-			nil,
-			exchanged{nil, 0, nil},
-		},
-		{ // empty exchangers
-			nil,
-			stubs(),
-			exchanged{nil, 0, nil},
-		},
-		{ // false predicate
-			func(calls int) Pred {
-				return func(*dns.Msg) bool {
-					calls++
-					return calls != 2
-				}
-			}(0),
-			stubs(exchanged{nil, 0, nil}, exchanged{nil, 1, nil}, exchanged{nil, 2, nil}),
-			exchanged{nil, 1, nil},
-		},
-	} {
-		var got exchanged
-		got.m, got.rtt, got.err = While(tt.pred, tt.exs...).Exchange(nil, "")
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+func TestErrorLogging(t *testing.T) {
+	{ // with error
+		var buf bytes.Buffer
+		_, _, _ = ErrorLogging(log.New(&buf, "", 0))(
+			stub(exchanged{err: errors.New("timeout")})).Exchange(nil, "1.2.3.4")
+
+		want := "timeout: exchanging (*dns.Msg)(nil) with \"1.2.3.4\"\n"
+		if got := buf.String(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+	{ // no error
+		var buf bytes.Buffer
+		_, _, _ = ErrorLogging(log.New(&buf, "", 0))(
+			stub(exchanged{})).Exchange(nil, "1.2.3.4")
+
+		if got, want := buf.String(), ""; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }
 
-func TestRecurse(t *testing.T) {
-	for i, tt := range []struct {
-		*dns.Msg
-		want string
-	}{
-		{ // Authoritative with answers
-			Message(
-				Header(true, 0),
-				Answers(
-					A(RRHeader("localhost", dns.TypeA, 0), net.IPv6loopback.To4()),
-				),
-				NSs(
-					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
-				),
-			),
-			"",
-		},
-		{ // Authoritative, empty answers, no SOA records
-			Message(
-				Header(true, 0),
-				NSs(
-					NS(RRHeader("", dns.TypeNS, 0), "next"),
-				),
-			),
-			"",
-		},
-		{ // Not authoritative, no SOA record
-			Message(Header(false, 0)),
-			"",
-		},
-		{ // Not authoritative, one SOA record
-			Message(
-				Header(false, 0),
-				NSs(SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0)),
-			),
-			"next:53",
-		},
-		{ // Authoritative, empty answers, one SOA record
-			Message(
-				Header(true, 0),
-				NSs(
-					NS(RRHeader("", dns.TypeNS, 0), "foo"),
-					SOA(RRHeader("", dns.TypeSOA, 0), "next", "", 0),
-				),
-			),
-			"next:53",
-		},
-	} {
-		if got := Recurse(tt.Msg); got != tt.want {
-			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+func TestInstrumentation(t *testing.T) {
+	{ // with error
+		var total, success, failure logging.LogCounter
+		_, _, _ = Instrumentation(&total, &success, &failure)(
+			stub(exchanged{err: errors.New("timeout")})).Exchange(nil, "1.2.3.4")
+
+		want := []string{"1", "0", "1"}
+		for i, c := range []*logging.LogCounter{&total, &success, &failure} {
+			if got, want := c.String(), want[i]; got != want {
+				t.Errorf("test #%d: got %q, want %q", i, got, want)
+			}
 		}
 	}
-}
+	{ // no error
+		var total, success, failure logging.LogCounter
+		_, _, _ = Instrumentation(&total, &success, &failure)(
+			stub(exchanged{})).Exchange(nil, "1.2.3.4")
 
-func TestRecursion(t *testing.T) {
-	for i, tt := range []struct {
-		max  int
-		rec  Recurser
-		ex   Exchanger
-		want exchanged
-	}{
-		{
-			0,
-			func(*dns.Msg) string { return "next" },
-			seq(stubs(exchanged{rtt: 1})...),
-			exchanged{rtt: 1},
-		},
-		{
-			1,
-			func(*dns.Msg) string { return "next" },
-			seq(stubs(exchanged{rtt: 0}, exchanged{rtt: 1}, exchanged{rtt: 2})...),
-			exchanged{rtt: 1},
-		},
-		{
-			0,
-			nil,
-			seq(stubs(exchanged{err: errors.New("foo")})...),
-			exchanged{err: errors.New("foo")},
-		},
-		{
-			2,
-			func(calls int) Recurser {
-				return func(*dns.Msg) string {
-					if calls++; calls <= 1 {
-						return "next"
-					}
-					return ""
-				}
-			}(0),
-			seq(stubs(exchanged{rtt: 0}, exchanged{rtt: 1}, exchanged{rtt: 2})...),
-			exchanged{rtt: 1},
-		},
-	} {
-		var got exchanged
-		got.m, got.rtt, got.err = Recursion(tt.max, tt.rec)(tt.ex).Exchange(nil, "")
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("test #%d: got: %v, want: %v", i, got, tt.want)
+		want := []string{"1", "1", "0"}
+		for i, c := range []*logging.LogCounter{&total, &success, &failure} {
+			if got, want := c.String(), want[i]; got != want {
+				t.Errorf("test #%d: got %q, want %q", i, got, want)
+			}
 		}
 	}
-}
-
-func seq(exs ...Exchanger) Exchanger {
-	var i int
-	return Func(func(m *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
-		ex := exs[i]
-		i++
-		return ex.Exchange(m, a)
-	})
 }
 
 func stubs(ed ...exchanged) []Exchanger {

--- a/exchanger/forwarder.go
+++ b/exchanger/forwarder.go
@@ -1,0 +1,49 @@
+package exchanger
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// A Forwarder is a DNS message forwarder that transparently proxies messages
+// to DNS servers.
+type Forwarder func(*dns.Msg, string) (*dns.Msg, error)
+
+// Forward is an utility method that calls f itself.
+func (f Forwarder) Forward(m *dns.Msg, proto string) (*dns.Msg, error) {
+	return f(m, proto)
+}
+
+// NewForwarder returns a new Forwarder for the given addrs with the given
+// Exchangers map which maps network protocols to Exchangers.
+//
+// Every message will be exchanged with each address until no error is returned.
+// If no addresses or no matching protocol exchanger exist, a *ForwardError will
+// be returned.
+func NewForwarder(addrs []string, exs map[string]Exchanger) Forwarder {
+	return func(m *dns.Msg, proto string) (r *dns.Msg, err error) {
+		ex, ok := exs[proto]
+		if !ok || len(addrs) == 0 {
+			return nil, &ForwardError{Addrs: addrs, Proto: proto}
+		}
+		for _, a := range addrs {
+			if r, _, err = ex.Exchange(m, net.JoinHostPort(a, "53")); err == nil {
+				break
+			}
+		}
+		return
+	}
+}
+
+// A ForwardError is returned by Forwarders when they can't forward.
+type ForwardError struct {
+	Addrs []string
+	Proto string
+}
+
+// Error implements the error interface.
+func (e ForwardError) Error() string {
+	return fmt.Sprintf("can't forward to %v over %q", e.Addrs, e.Proto)
+}

--- a/exchanger/forwarder_test.go
+++ b/exchanger/forwarder_test.go
@@ -1,0 +1,95 @@
+package exchanger
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	. "github.com/mesosphere/mesos-dns/dnstest"
+	"github.com/miekg/dns"
+)
+
+func TestForwarder(t *testing.T) {
+	exs := func(e exchanged, protos ...string) map[string]Exchanger {
+		es := make(map[string]Exchanger, len(protos))
+		for _, proto := range protos {
+			es[proto] = stub(e)
+		}
+		return es
+	}
+
+	msg := Message(Question("foo.bar", dns.TypeA))
+	for i, tt := range []struct {
+		addrs []string
+		exs   map[string]Exchanger
+		proto string
+		r     *dns.Msg
+		err   error
+	}{
+		{ // no matching protocol
+			nil, exs(exchanged{}, "udp"), "tcp", nil, &ForwardError{nil, "tcp"},
+		},
+		{ // matching protocol, no addrs
+			nil, exs(exchanged{}, "udp"), "udp", nil, &ForwardError{nil, "udp"},
+		},
+		{ // matching protocol, no addrs
+			[]string{}, exs(exchanged{}, "udp"), "udp", nil, &ForwardError{[]string{}, "udp"},
+		},
+		{ // matching protocol, one addr, no error exchanging
+			addrs: []string{"1.2.3.4"},
+			exs:   exs(exchanged{m: msg}, "udp"),
+			proto: "udp",
+			r:     msg,
+		},
+		{ // matching protocol, one addr, error exchanging
+			addrs: []string{"1.2.3.4"},
+			exs:   exs(exchanged{err: errors.New("timeout")}, "udp"),
+			proto: "udp",
+			err:   errors.New("timeout"),
+		},
+		{ // matching protocol, two addrs, error exchanging with the first only
+			addrs: []string{"1.2.3.4", "2.3.4.5"},
+			exs: map[string]Exchanger{
+				"udp": Func(func(_ *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
+					switch a {
+					case "1.2.3.4":
+						return nil, 0, errors.New("timeout")
+					default:
+						return msg, 0, nil
+					}
+				}),
+			},
+			proto: "udp",
+			r:     msg,
+		},
+		{ // matching protocol, two addrs, error exchanging with all of them
+			addrs: []string{"1.2.3.4", "2.3.4.5"},
+			exs: map[string]Exchanger{
+				"udp": Func(func(_ *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
+					switch a {
+					case "1.2.3.4":
+						return nil, 0, errors.New("timeout")
+					default:
+						return nil, 0, errors.New("eof")
+					}
+				}),
+			},
+			proto: "udp",
+			err:   errors.New("eof"),
+		},
+	} {
+		var got forwarded
+		got.r, got.err = NewForwarder(tt.addrs, tt.exs).Forward(nil, tt.proto)
+		if want := (forwarded{r: tt.r, err: tt.err}); !reflect.DeepEqual(got, want) {
+			t.Logf("test #%d\n", i)
+			t.Error(pretty.Compare(got, want))
+		}
+	}
+}
+
+type forwarded struct {
+	r   *dns.Msg
+	err error
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -46,28 +46,28 @@ func (lc *LogCounter) String() string {
 
 // LogOut holds metrics captured in an instrumented runtime.
 type LogOut struct {
-	MesosRequests    Counter
-	MesosSuccess     Counter
-	MesosNXDomain    Counter
-	MesosFailed      Counter
-	NonMesosRequests Counter
-	NonMesosSuccess  Counter
-	NonMesosNXDomain Counter
-	NonMesosFailed   Counter
-	NonMesosRecursed Counter
+	MesosRequests     Counter
+	MesosSuccess      Counter
+	MesosNXDomain     Counter
+	MesosFailed       Counter
+	NonMesosRequests  Counter
+	NonMesosSuccess   Counter
+	NonMesosNXDomain  Counter
+	NonMesosFailed    Counter
+	NonMesosForwarded Counter
 }
 
 // CurLog is the default package level LogOut.
 var CurLog = LogOut{
-	MesosRequests:    &LogCounter{},
-	MesosSuccess:     &LogCounter{},
-	MesosNXDomain:    &LogCounter{},
-	MesosFailed:      &LogCounter{},
-	NonMesosRequests: &LogCounter{},
-	NonMesosSuccess:  &LogCounter{},
-	NonMesosNXDomain: &LogCounter{},
-	NonMesosFailed:   &LogCounter{},
-	NonMesosRecursed: &LogCounter{},
+	MesosRequests:     &LogCounter{},
+	MesosSuccess:      &LogCounter{},
+	MesosNXDomain:     &LogCounter{},
+	MesosFailed:       &LogCounter{},
+	NonMesosRequests:  &LogCounter{},
+	NonMesosSuccess:   &LogCounter{},
+	NonMesosNXDomain:  &LogCounter{},
+	NonMesosFailed:    &LogCounter{},
+	NonMesosForwarded: &LogCounter{},
 }
 
 // PrintCurLog prints out the current LogOut and then resets

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -11,11 +11,9 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 	. "github.com/mesosphere/mesos-dns/dnstest"
-	"github.com/mesosphere/mesos-dns/exchanger"
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records"
 	"github.com/mesosphere/mesos-dns/records/labels"
@@ -77,19 +75,19 @@ func TestShuffleAnswers(t *testing.T) {
 
 func TestHandlers(t *testing.T) {
 	res := fakeDNS(t)
-	res.extResolver = exchanger.Func(func(m *dns.Msg, a string) (*dns.Msg, time.Duration, error) {
+	res.fwd = func(m *dns.Msg, net string) (*dns.Msg, error) {
 		rr1, err := res.formatA("google.com.", "1.1.1.1")
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		rr2, err := res.formatA("google.com.", "2.2.2.2")
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		msg := &dns.Msg{Answer: []dns.RR{rr1, rr2}}
 		msg.SetReply(m)
-		return msg, 0, nil
-	})
+		return msg, nil
+	}
 
 	for i, tt := range []struct {
 		dns.HandlerFunc


### PR DESCRIPTION
The original external queries code mixed concepts of a proxy (forwarder) and a recurser for no good apparent reason. As per https://tools.ietf.org/html/rfc5625, this change set simplifies things.

Related to #297, #298.
Closes #301.