### PR TITLE
Proposal: Generate records for staging tasks

### DIFF
--- a/records/state/state.go
+++ b/records/state/state.go
@@ -162,7 +162,8 @@ func statusIPs(st []Status, src func(*Status) []string) []string {
 	// https://github.com/apache/mesos/blob/0.24.0/src/slave/slave.cpp#L5226-L5238
 	ts, j := -1.0, -1
 	for i := range st {
-		if st[i].State == "TASK_RUNNING" && st[i].Timestamp > ts {
+		state := st[i].State
+		if (state == "TASK_RUNNING" || state == "TASK_STAGING") && st[i].Timestamp > ts {
 			ts, j = st[i].Timestamp, i
 		}
 	}


### PR DESCRIPTION
In some cases it is desirable for a Task to depend on resolution of its
own DNS address before it reports itself as RUNNING.  It's currently
impossible because DNS addresses are only generated for RUNNING Tasks.
This leads to the undesirable scenario of having to lie to Mesos in
order to get a DNS address generated.

There may be unknown legacy reasons why this policy has been instituted, that I don't know about.  I also haven't tested this etc.  This PR is mostly to get feedback about what's going on here.  If this just wasn't a supported scenario before, and it's a reasonable change I'm happy to test and do whatever else is required.
