### PR TITLE
resolver: Fix data races

### DIFF
--- a/resolver/rand.go
+++ b/resolver/rand.go
@@ -1,0 +1,25 @@
+package resolver
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// lockedSource wraps a rand.Source with a sync.Mutex for synchronization.
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -148,7 +148,7 @@ func (res *Resolver) Reload() {
 		// may need to refactor for fairness
 		res.rsLock.Lock()
 		defer res.rsLock.Unlock()
-		res.config.SOASerial = timestamp
+		atomic.StoreUint32(&res.config.SOASerial, timestamp)
 		res.rs = &t
 	} else {
 		logging.VeryVerbose.Println("Warning: master not found; keeping old DNS state")
@@ -214,7 +214,7 @@ func (res *Resolver) formatSOA(dom string) (*dns.SOA, error) {
 		},
 		Ns:      res.config.SOAMname,
 		Mbox:    res.config.SOARname,
-		Serial:  res.config.SOASerial,
+		Serial:  atomic.LoadUint32(&res.config.SOASerial),
 		Refresh: res.config.SOARefresh,
 		Retry:   res.config.SOARetry,
 		Expire:  res.config.SOAExpire,


### PR DESCRIPTION
While performing the load test for #314, two data races manifested.
This commit fixes both of them.