### PR TITLE
Move repo to Go 1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp/
 config.json
 mesos-dns
 *.gz
+VERSION

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ The official distribution and installation channel is pre-compiled binaries avai
 Building the **master** branch from source should always succeed but doesn't provide
 the same stability and compatibility guarantees as releases.
 
-All dependencies are vendored using `Godeps` which require you to
-install it in order to build from source.
+All branches and pull requests are tested by [Circle-CI](https://circleci.com/gh/mesosphere/mesos-dns), which also
+outputs artifacts for Mac OS X, Windows, and Linux via cross-compilation.
+
+You will need [Go](https://golang.org/) *1.5* or later to build the project.
+All dependencies are vendored using `Godeps`. You must first install it in order to build from source.
 
 ```shell
 $ go get github.com/tools/godep

--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,29 @@
+machine:
+  pre:
+    - wget https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz
+    - tar zxvf go1.5.1.linux-amd64.tar.gz
+  environment:
+    GOROOT: ${HOME}/go
+    PATH: ${GOROOT}/bin:${PATH}
+  post:
+    - go version
+
 dependencies:
   pre:
+    - go version
+    - go get github.com/mitchellh/gox
     - go get github.com/tools/godep
     - go get github.com/alecthomas/gometalinter
     - go get github.com/axw/gocov/gocov # https://github.com/golang/go/issues/6909
     - go get github.com/mattn/goveralls
     - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+    - git describe --tags > VERSION
   post:
     - go install ./...
     - go test -i ./...
     - gometalinter --install
+    - gox -arch=amd64 -os="linux darwin windows" -output="${CIRCLE_ARTIFACTS}/{{.Dir}}-$(<VERSION)-{{.OS}}-{{.Arch}}" -ldflags="-X main.Version=$(<VERSION)"
+
 
 test:
   override:


### PR DESCRIPTION
-Add Go1.5 to the Circle-CI build environment
-Add documentation about the go1.5 build to README
-Make Circle-CI output build artifacts with go1.5