### PR TITLE
Move to use Go's built in coverage command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.json
 mesos-dns
 *.gz
 VERSION
+cov.json

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,6 @@ dependencies:
     - go get github.com/alecthomas/gometalinter
     - go get github.com/axw/gocov/gocov # https://github.com/golang/go/issues/6909
     - go get github.com/mattn/goveralls
-    - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
     - git describe --tags > VERSION
   post:
     - go install ./...


### PR DESCRIPTION
  - Go coverage has been pulled in to go 1.5 (https://golang.org/cmd/cover/)
  - Remove fetching Go's coverage tool from code.google.com (deprecated)