### PR TITLE
Use Mesos 0.26 version of NetworkInfo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+TBD: v-next
+  Use Mesos 0.26 version of NetworkInfo - breaks compatibility with Mesos 0.25 (#345)
+
 2015-10-09: v0.4.0
   Smarter leading Mesos master detection timeout logic (#284, #306, #320)
   resolver: Fix data races to RNG and SOASerial (#317)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ is considered **alpha**. We have adopted a [semantic versioning](http://semver.o
 
 ## Compatibility
 `mesos-N` tags mark the start of support for a specific Mesos version while
-maintaining backwards compatibility with the previous major version.
+maintaining backwards compatibility with the previous major version. 
+This release breaks compatibility with handling NetworkInfo on versions
+before 0.26. It is compatible with Mesos 0.26 and newer.
 
 ## Installing
 The official distribution and installation channel is pre-compiled binaries available in [Github releases](https://github.com/mesosphere/mesos-dns/releases).

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -59,9 +59,17 @@ type ContainerStatus struct {
 	NetworkInfos []NetworkInfo `json:"network_infos,omitempty"`
 }
 
-// NetworkInfo holds a network address resolution as defined in the
-// /state.json Mesos HTTP endpoint.
+// NetworkInfo holds the network configuration for a single interface
+// as defined in the /state.json Mesos HTTP endpoint.
 type NetworkInfo struct {
+	IPAddresses []IPAddress `json:"ip_addresses,omitempty"`
+	// back-compat with 0.25 IPAddress format
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+// IPAddress holds a single IP address configured on an interface,
+// as defined in the /state.json Mesos HTTP endpoint.
+type IPAddress struct {
 	IPAddress string `json:"ip_address,omitempty"`
 }
 
@@ -123,12 +131,22 @@ var sources = map[string]func(*Task) []string{
 func hostIPs(t *Task) []string { return []string{t.SlaveIP} }
 
 // networkInfoIPs returns IP addresses from a given Task's
-// []Status.ContainerStatus.[]NetworkInfos.IPAddress
+// []Status.ContainerStatus.[]NetworkInfos.[]IPAddresses.IPAddress
 func networkInfoIPs(t *Task) []string {
 	return statusIPs(t.Statuses, func(s *Status) []string {
 		ips := make([]string, len(s.ContainerStatus.NetworkInfos))
-		for i, netinfo := range s.ContainerStatus.NetworkInfos {
-			ips[i] = netinfo.IPAddress
+		for _, netinfo := range s.ContainerStatus.NetworkInfos {
+			if len(netinfo.IPAddresses) > 0 {
+				// In v0.26, we use the IPAddresses field.
+				for _, ipAddress := range netinfo.IPAddresses {
+					ips = append(ips, ipAddress.IPAddress)
+				}
+			} else {
+				// Fall back to v0.25 syntax of single IPAddress if that's being used.
+				if netinfo.IPAddress != "" {
+					ips = append(ips, netinfo.IPAddress)
+				}
+			}
 		}
 		return ips
 	})


### PR DESCRIPTION
In MESOS-3788, the NetworkInfo message was updated to clarify
the structure of how IPs map onto interfaces.

Update mesos-dns to use the new NetworkInfo.