### PR TITLE
Fix errant NXDOMAIN errors & return notimplemented on AAAA

### DIFF
--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -173,6 +173,15 @@ func runHandlers() error {
 		{
 			res.HandleMesos,
 			Message(
+				Question("_car-store._udp.marathon.mesos.", dns.TypeA),
+				Header(true, dns.RcodeSuccess),
+				NSs(
+					SOA(RRHeader("_car-store._udp.marathon.mesos.", dns.TypeSOA, 60),
+						"ns1.mesos", "root.ns1.mesos", 60))),
+		},
+		{
+			res.HandleMesos,
+			Message(
 				Question("non-existing.mesos.", dns.TypeSOA),
 				Header(true, dns.RcodeSuccess),
 				NSs(
@@ -209,7 +218,7 @@ func runHandlers() error {
 			res.HandleMesos,
 			Message(
 				Question("missing.mesos.", dns.TypeAAAA),
-				Header(true, dns.RcodeNameError),
+				Header(true, dns.RcodeSuccess),
 				NSs(
 					SOA(RRHeader("missing.mesos.", dns.TypeSOA, 60),
 						"ns1.mesos", "root.ns1.mesos", 60))),


### PR DESCRIPTION
Related to #365. This is a work around. Although the pattern for all the other records is to add a handle$RECORDTYPE, unless we implement AAAA records, it'll always fall through to this function, which would have marked it with RcodeNameError. I think that RcodeSuccess is the most appriopriate response based upon:  https://tools.ietf.org/html/rfc4074.
I also looked at using RcodeNotImplemented, but it sounds like it's misbehaving according to that doc. 

This means that if someone searches for AAAA, they'll _always_ getting a positive cache for the record, and then they can do subsequent queries
CC: @jdef 