### PR TITLE
add EnforceRFC952 to sample config

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -21,5 +21,6 @@
   "httpport": 8123,
   "externalon": true,
   "recurseon": true,
-  "IPSources": ["mesos", "host"]
+  "IPSources": ["mesos", "host"],
+  "EnforceRFC952": false
 }


### PR DESCRIPTION
Option is available but currently absent from the sample config. People who get mesos-dns as a binary package are likely to check the sample config first for available options. So I think it makes sense to have all possible options in there.