### PR TITLE
Fixes #377 - Apply label schema to task.DiscoveryInfo.Name

### DIFF
--- a/factories/fake.json
+++ b/factories/fake.json
@@ -223,7 +223,7 @@
                     "executor_id": "",
                     "framework_id": "20140703-014514-3041283216-5050-5348-0000",
                     "id": "liquor-store.b8db9f73-562f-11e4-a088-c20493233aa5",
-                    "name": "liquor-store",
+                    "name": "liquor.store",
                     "resources": {
                         "cpus": 1,
                         "disk": 0,
@@ -283,7 +283,7 @@
                     "discovery" : {
                         "version" : "1.0",
                         "visibility" : "CLUSTER",
-                        "name" : "liquor-store",
+                        "name" : "liquor.store",
                         "ports" : {
                             "ports" : [
                                 {
@@ -346,7 +346,7 @@
                     "discovery" : {
                         "version" : "1.0",
                         "visibility" : "CLUSTER",
-                        "name" : "liquor-store",
+                        "name" : "liquor.store",
                         "ports" : {
                             "ports" : [
                                 {
@@ -381,7 +381,7 @@
                     "executor_id": "",
                     "framework_id": "20140703-014514-3041283216-5050-5348-0000",
                     "id": "car-store.43758382-562f-11e4-a088-c20493233aa5",
-                    "name": "car-store",
+                    "name": "car.store",
                     "resources": {
                         "cpus": 1,
                         "disk": 0,

--- a/records/generator.go
+++ b/records/generator.go
@@ -387,7 +387,7 @@ func (rg *RecordGenerator) taskRecords(sj state.State, domain string, spec label
 
 			// use DiscoveryInfo name if defined instead of task name
 			if task.HasDiscoveryInfo() {
-				ctx.taskName = task.DiscoveryInfo.Name
+				ctx.taskName = spec(task.DiscoveryInfo.Name)
 			}
 
 			// insert canonical A records


### PR DESCRIPTION
It is necessary to treat task.DiscoveryInfo.Name in the same way as
task.Name, otherwise mesos-dns will use a different naming schema for
tasks that include DiscoveryInfo.