### PR TITLE
generate additional SRV records if port name is specified

### DIFF
--- a/records/chains.go
+++ b/records/chains.go
@@ -1,0 +1,80 @@
+package records
+
+import (
+	"github.com/mesosphere/mesos-dns/records/labels"
+)
+
+// chain is a generation func that consumes record-like strings and does
+// something with them
+type chain func(...string)
+
+const (
+	protocolNone = "" // for readability
+	domainNone   = "" // for readability
+)
+
+// withProtocol appends `._{protocol}.{framework}` to records. if protocol is "" then
+// the protocols "tcp" and "udp" are assumed.
+func withProtocol(protocol, framework string, spec labels.Func, gen chain) chain {
+	return func(records ...string) {
+		protocol = spec(protocol)
+		if protocol != protocolNone {
+			for i := range records {
+				records[i] += "._" + protocol + "." + framework
+			}
+		} else {
+			records = append(records, records...)
+			for i, j := 0, len(records)/2; j < len(records); {
+				records[i] += "._tcp." + framework
+				records[j] += "._udp." + framework
+				i++
+				j++
+			}
+		}
+		gen(records...)
+	}
+}
+
+// withSubdomains appends `.{subdomain}` (for each subdomain spec'd) to records.
+// the empty subdomain "" indicates to generate records w/o a subdomain fragment.
+func withSubdomains(subdomains []string, gen chain) chain {
+	if len(subdomains) == 0 {
+		return gen
+	}
+	return func(records ...string) {
+		var (
+			recordLen = len(records)
+			tmp       = make([]string, recordLen*len(subdomains))
+			offset    = 0
+		)
+		for s := range subdomains {
+			if subdomains[s] == domainNone {
+				copy(tmp[offset:], records)
+			} else {
+				for i := range records {
+					tmp[offset+i] = records[i] + "." + subdomains[s]
+				}
+			}
+			offset += recordLen
+		}
+		gen(tmp...)
+	}
+}
+
+// withNamedPort prepends a `_{discoveryInfo port name}.` to records
+func withNamedPort(portName string, spec labels.Func, gen chain) chain {
+	portName = spec(portName)
+	if portName == "" {
+		return gen
+	}
+	return func(records ...string) {
+		// generate without port-name prefix
+		gen(records...)
+
+		// generate with port-name prefix
+		for i := range records {
+			records[i] = "_" + portName + "." + records[i]
+		}
+		gen(records...)
+	}
+}

--- a/records/generator.go
+++ b/records/generator.go
@@ -526,6 +526,19 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 	for _, port := range task.DiscoveryInfo.Ports.DiscoveryPorts {
 		target := canonical + tail + ":" + strconv.Itoa(port.Number)
 
+		// special SRV records if a discovery port has a name
+		if portName := spec(port.Name); portName != "" {
+			// _portName._protocol.taskName.fname.tail
+			protocols := []string{"tcp", "udp"}
+			if customProto := spec(port.Protocol); customProto != "" {
+				protocols = []string{customProto}
+			}
+			for _, proto := range protocols {
+				name := "_" + portName + "._" + proto + "." + ctx.taskName + "." + fname
+				rg.insertTaskRR(name+tail, target, SRV, enumTask)
+			}
+		}
+
 		// use protocol if defined, fallback to tcp+udp
 		proto := spec(port.Protocol)
 		if proto != "" {

--- a/records/generator.go
+++ b/records/generator.go
@@ -503,20 +503,32 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 	rg.insertTaskRR(arec+".slave"+tail, ctx.slaveIP, A, enumTask)
 	rg.insertTaskRR(canonical+".slave"+tail, ctx.slaveIP, A, enumTask)
 
+	// recordName generates records for ctx.taskName, given some generation chain
+	recordName := func(gen chain) { gen("_" + ctx.taskName) }
+
+	// asSRV is always the last link in a chain, it must insert RR's
+	asSRV := func(target string) chain {
+		return func(records ...string) {
+			for i := range records {
+				name := records[i] + tail
+				rg.insertTaskRR(name, target, SRV, enumTask)
+			}
+		}
+	}
+
 	// Add RFC 2782 SRV records
+	var subdomains []string
+	if task.HasDiscoveryInfo() {
+		subdomains = []string{"slave"}
+	} else {
+		subdomains = []string{"slave", domainNone}
+	}
+
 	slaveHost := canonical + ".slave" + tail
-	tcpName := "_" + ctx.taskName + "._tcp." + fname
-	udpName := "_" + ctx.taskName + "._udp." + fname
 	for _, port := range task.Ports() {
 		slaveTarget := slaveHost + ":" + port
-
-		if !task.HasDiscoveryInfo() {
-			rg.insertTaskRR(tcpName+tail, slaveTarget, SRV, enumTask)
-			rg.insertTaskRR(udpName+tail, slaveTarget, SRV, enumTask)
-		}
-
-		rg.insertTaskRR(tcpName+".slave"+tail, slaveTarget, SRV, enumTask)
-		rg.insertTaskRR(udpName+".slave"+tail, slaveTarget, SRV, enumTask)
+		recordName(withProtocol(protocolNone, fname, spec,
+			withSubdomains(subdomains, asSRV(slaveTarget))))
 	}
 
 	if !task.HasDiscoveryInfo() {
@@ -525,31 +537,9 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 
 	for _, port := range task.DiscoveryInfo.Ports.DiscoveryPorts {
 		target := canonical + tail + ":" + strconv.Itoa(port.Number)
-
-		// special SRV records if a discovery port has a name
-		if portName := spec(port.Name); portName != "" {
-			// _portName._protocol.taskName.fname.tail
-			protocols := []string{"tcp", "udp"}
-			if customProto := spec(port.Protocol); customProto != "" {
-				protocols = []string{customProto}
-			}
-			for _, proto := range protocols {
-				name := "_" + portName + "._" + proto + "." + ctx.taskName + "." + fname
-				rg.insertTaskRR(name+tail, target, SRV, enumTask)
-			}
-		}
-
-		// use protocol if defined, fallback to tcp+udp
-		proto := spec(port.Protocol)
-		if proto != "" {
-			name := "_" + ctx.taskName + "._" + proto + "." + fname
-			rg.insertTaskRR(name+tail, target, SRV, enumTask)
-		} else {
-			rg.insertTaskRR(tcpName+tail, target, SRV, enumTask)
-			rg.insertTaskRR(udpName+tail, target, SRV, enumTask)
-		}
+		recordName(withProtocol(port.Protocol, fname, spec,
+			withNamedPort(port.Name, spec, asSRV(target))))
 	}
-
 }
 
 // A records for each local interface

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -235,6 +235,14 @@ func TestInsertState(t *testing.T) {
 		}},
 		{rg.SRVs, "_liquor-store._udp.marathon.mesos.", nil},
 		{rg.SRVs, "_liquor-store.marathon.mesos.", nil},
+		{rg.SRVs, "_https._liquor-store._tcp.marathon.mesos.", []string{
+			"liquor-store-4dfjd-0.marathon.mesos.:443",
+			"liquor-store-zasmd-1.marathon.mesos.:443",
+		}},
+		{rg.SRVs, "_http._liquor-store._tcp.marathon.mesos.", []string{
+			"liquor-store-4dfjd-0.marathon.mesos.:80",
+			"liquor-store-zasmd-1.marathon.mesos.:80",
+		}},
 		{rg.SRVs, "_car-store._tcp.marathon.mesos.", []string{
 			"car-store-zinaz-0.marathon.slave.mesos.:31364",
 			"car-store-zinaz-0.marathon.slave.mesos.:31365",


### PR DESCRIPTION
related to #61 

summary: if s task provides a discoveryInfo w/ named ports then mesos-dns will generate additional SRV records for those ports: `_{di-port-name}._{task-name}._{protocol}.{framework}.{domain}.`