### PR TITLE
added benchmark for RecordGenerator.insertRR

### DIFF
--- a/records/generator_perf_test.go
+++ b/records/generator_perf_test.go
@@ -1,0 +1,38 @@
+package records
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+// BenchmarkInsertRR *only* tests insertRR, not the taskRecord funcs.
+func BenchmarkInsertRR(b *testing.B) {
+	const (
+		clusterSize = 1000
+		appCount    = 5
+	)
+	var (
+		slaves = make([]string, clusterSize)
+		apps   = make([]string, appCount)
+		rg     = &RecordGenerator{
+			As:   rrs{},
+			SRVs: rrs{},
+		}
+	)
+	for i := 0; i < clusterSize; i++ {
+		slaves[i] = "slave" + strconv.Itoa(i)
+	}
+	for i := 0; i < appCount; i++ {
+		apps[i] = "app" + strconv.Itoa(i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var (
+			si = rand.Int31n(clusterSize)
+			ai = rand.Int31n(appCount)
+		)
+		rg.insertRR(apps[ai], slaves[si], "A")
+	}
+}


### PR DESCRIPTION
- fixes #408 

Micro-benchmark (take with a grain of salt) shows about 20x gain in performance.

Before improvements in #395:
```
BenchmarkInsertRR         500000              2394 ns/op
BenchmarkInsertRR         500000              2383 ns/op
BenchmarkInsertRR         500000              2402 ns/op
BenchmarkInsertRR         500000              2439 ns/op
BenchmarkInsertRR         500000              2423 ns/op
BenchmarkInsertRR         500000              2412 ns/op
```

After:
```
BenchmarkInsertRR       10000000               139 ns/op
BenchmarkInsertRR       10000000               147 ns/op
BenchmarkInsertRR       10000000               140 ns/op
BenchmarkInsertRR       10000000               139 ns/op
BenchmarkInsertRR       10000000               138 ns/op
BenchmarkInsertRR       10000000               147 ns/op
```
