### PR TITLE
Add support for zone-specific resolvers

### DIFF
--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -22,6 +22,9 @@ The configuration file should include the following fields:
   "domain": "mesos",
   "port": 53,
   "resolvers": ["169.254.169.254"],
+  "zoneResolvers": {
+    "weave": ["172.17.0.1"]
+  },
   "timeout": 5, 
   "httpon": true,
   "dnson": true,
@@ -71,7 +74,9 @@ It is sufficient to specify just one of the `zk` or `masters` field. If both are
 `port` is the port number that Mesos-DNS monitors for incoming DNS requests. Requests can be sent over TCP or UDP. We recommend you use port `53` as several applications assume that the DNS server listens to this port. The default value is `53`.
 
 `resolvers` is a comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the `domain`. We ***recommend*** that you list the nameservers specified in the `/etc/resolv.conf` on the server Mesos-DNS is running. Alternatively, you can list `8.8.8.8`, which is the [Google public DNS](https://developers.google.com/speed/public-dns/) address. The `resolvers` field is required. 
- 
+
+`zoneResolvers` is a dictionary of zone-specific external DNS servers, where the key is the matching zone (sans leading / trailing .). You can use this configuration option to route a subset of DNS queries to a specific set of DNS servers. Note, general, catch-all resolvers are still specified with `resolvers`.
+
 `timeout` is the timeout threshold, in seconds, for connections and requests to external DNS requests. The default value is 5 seconds. 
 
 `listener` is the IP address of Mesos-DNS. In SOA replies, Mesos-DNS identifies hostname `mesos-dns.domain` as the primary nameserver for the domain. It uses this IP address in an A record for `mesos-dns.domain`. The default value is "0.0.0.0", which instructs Mesos-DNS to create an A record for every IP address associated with a network interface on the server that runs the Mesos-DNS process. 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -94,7 +94,7 @@ func runHandlers() error {
 	if err != nil {
 		return err
 	}
-	res.fwd = func(m *dns.Msg, net string) (*dns.Msg, error) {
+	fwd := func(m *dns.Msg, net string) (*dns.Msg, error) {
 		rr1, err := res.formatA("google.com.", "1.1.1.1")
 		if err != nil {
 			return nil, err
@@ -218,7 +218,7 @@ func runHandlers() error {
 						"ns1.mesos", "root.ns1.mesos", 60))),
 		},
 		{
-			res.HandleNonMesos,
+			res.HandleNonMesos(fwd),
 			Message(
 				Question("google.com.", dns.TypeA),
 				Header(false, dns.RcodeSuccess),


### PR DESCRIPTION
This is a work-in-progress pull request.

This patch adds the ability to configure zone-specific upstream forwarders, which can help simplify the deployment of mesos-dns when other multiple dns providers are used (IE weave).

An example of the configuration could look like this:

```
{
  "zk": "zk://10.141.141.10:2181,10.141.141.11:2181,10.141.141.12:2181/mesos",
  "masters": ["10.141.141.10:5050","10.141.141.11:5050","10.141.141.12:5050"],
  "refreshSeconds": 60,
  "ttl": 60,
  "domain": "mesos",
  "ns": "ns1",
  "port": 53,
  "zoneResolvers": {"weave.local": ["172.17.0.1"]},
  "resolvers": ["8.8.8.8", "4.2.2.1"],
  "timeout": 5,
  "listener": "10.141.141.10",
  "SOAMname": "root.ns1.mesos",
  "SOARname": "ns1.mesos",
  "SOARefresh": 60,
  "SOARetry":   600,
  "SOAExpire":  86400,
  "SOAMinttl": 60,
  "dnson": true,
  "httpon": true,
  "httpport": 8123,
  "externalon": true,
  "recurseon": true
}
```

TODO (prior to merge):

- (done?) Mesosphere should agree that this is a good idea
- (done) ~~The config should perhaps be generalized such that general resolvers and zone resolvers can be specified in the same data structure. `Resolvers` could be deprecated and backwards-compatibility retained.~~ (kept Resolvers, enforced no "" ZoneResolver)
- (done) Tests should be added.
- (done) Documentation should be updated.

Please let me know what you think of this change. Having this feature reduces the complexity of our DNS deployment significantly; if this change is violently rejected, we'll probably have to deploy a bind server in front of mesos-DNS, which adds a degree of complexity to our infrastructure.

