### PR TITLE
Adding dockerized build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build/mesos-dns*
+*/junit
+cov.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+junit/
 tmp/
 config.json
 mesos-dns

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,7 @@
+FROM golang:1.6.3
+
+COPY ./ "$GOPATH/src/github.com/mesosphere/mesos-dns"
+
+WORKDIR "$GOPATH/src/github.com/mesosphere/mesos-dns"
+
+RUN make deps

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,69 @@
-GOOS:=linux
-VERSION:=$(shell git describe --abbrev=4 --always --tags)
 NAME:=mesos-dns
-CONTAINERNAME:=$(NAME)
+BUILD_CONTAINER:=$(NAME)-build
+BUILD_DIR:=$(PWD)/build
 CIRCLE_TEST_REPORTS?=$(PWD)
 CIRCLE_ARTIFACTS?=$(PWD)/build
 COVERALLS_REPO_TOKEN?="tokennotset"
 DOCKER?=
+GOOS:=linux
+VERSION:=$(shell git describe --abbrev=4 --always --tags)
 
-all: $(if $(DOCKER), dockerbuild) test build
 
+.PHONY: help
+help:
+	@echo "all         - run all tests and compile mesos-dns"
+	@echo "artifacts   - compiles the program using gox for linux darwin and windows platforms"
+	@echo "build       - compiles the program, env GOOS can be set to specifiy platform"
+	@echo "buildstatic - compiles a statically linked program, env GOOS can be set to specify platform"
+	@echo "clean       - remove mesos-dns and mesos-dns-build docker images"
+	@echo "coveralls   - runs goveralls and uploads data to coveralls, env COVERALLS_REPO_TOKEN is needed"
+	@echo "dockerbuild - create mesos-dns-build docker image"
+	@echo "fmttest     - runs gofmt, returns 0 for success, 1 for failure"
+	@echo "gocov       - runs gocov"
+	@echo "gorace      - runs go test with race detection enabled"
+	@echo "junit       - runs go test and generates junit output"
+	@echo "metalinter  - runs gometalinter"
+	@echo "test        - runs fmttest and the various tests against the source code"
+	@echo "version     - display current version"
+
+.PHONY: all
+all: $(if $(DOCKER), dockerbuild, deps) test build
+
+.PHONY: artifacts
+artifacts: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm -v "$(CIRCLE_ARTIFACTS)":$(PWD)/output $(BUILD_CONTAINER)) gox \
+		-arch=amd64 \
+		-os="linux darwin windows" \
+		-output="$(PWD)/output/{{.Dir}}-$(VERSION)-{{.OS}}-{{.Arch}}" \
+		-ldflags="-X main.Version=$(VERSION)"
+
+.PHONY: build
+build: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":$(PWD)/build -e GOOS=$(GOOS) $(BUILD_CONTAINER), env GOOS=$(GOOS)) go build \
+		-ldflags="-X main.Version=$(VERSION)" \
+		-o $(PWD)/build/mesos-dns
+
+.PHONY: buildstatic
+buildstatic: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":$(PWD)/build -e CGO_ENABLED=0 -e GOOS=$(GOOS) $(BUILD_CONTAINER), env CGO_ENABLED=0 GOOS=$(GOOS)) go build \
+		-a \
+		-installsuffix cgo \
+		-ldflags "-s -X main.Version=$(VERSION)" \
+		-o $(PWD)/build/mesos-dns
+
+.PHONY: clean
+clean:
+	docker rmi $(BUILD_CONTAINER) || true
+	docker rmi $(BUILD_CONTAINER) || true
+
+.PHONY: coveralls
+coveralls: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)":/coveralls $(BUILD_CONTAINER)) goveralls \
+		-service=circleci \
+		-gocovdata=/coveralls/cov.json \
+		-repotoken=$(COVERALLS_REPO_TOKEN) || true
+
+.PHONY: deps
 deps:
 	go get -u github.com/kardianos/govendor
 	go get -u github.com/mitchellh/gox
@@ -21,77 +76,47 @@ deps:
 	go install ./...
 	go test -i ./...
 
+.PHONY: dockerbuild
 dockerbuild:
-	docker build -t $(CONTAINERNAME)-build -f Dockerfile.test .
-
-test: fmttest metalinter gocov junit gorace
+	docker build -t $(BUILD_CONTAINER) -f Dockerfile.test .
 
 ## Ignore vendored dependencies
 ## Return 1 if any files found that haven't been formatted
-fmttest: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gofmt -l . | \
-								awk '!/^vendor/ { print $0; err=1 }; END{ exit err }'
+.PHONY: fmttest
+fmttest: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm $(BUILD_CONTAINER)) gofmt -l . | \
+		awk '!/^vendor/ { print $0; err=1 }; END{ exit err }'
 
-junit: $(if $(DOCKER), dockerbuild)
+.PHONY: gocov
+gocov: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm $(BUILD_CONTAINER)) gocov test ./... -short -timeout=10m > $(PWD)/cov.json
+
+.PHONY: gorace
+gorace: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm $(BUILD_CONTAINER)) go test -v -short -race -timeout=10m ./...
+
+.PHONY: junit
+junit: $(if $(DOCKER), dockerbuild, deps)
 	mkdir -p $(CIRCLE_TEST_REPORTS)/junit
 	@# This seems odd, but if you attach stdin without attaching to an
 	@# output ( stdout or stderr ), the container runs in the background
-	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) go test -v -timeout=10m ./... | \
-	$(if $(DOCKER), docker run --rm -i -a stdin -a stdout -a stderr $(CONTAINERNAME)-build ) go-junit-report > $(CIRCLE_TEST_REPORTS)/junit/alltests.xml
+	$(if $(DOCKER), docker run --rm $(BUILD_CONTAINER)) go test -v -timeout=10m ./... | \
+	$(if $(DOCKER), docker run --rm -i $(BUILD_CONTAINER)) go-junit-report > $(CIRCLE_TEST_REPORTS)/junit/alltests.xml
 
-metalinter: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gometalinter \
-							--vendor \
-							--concurrency=6 \
-							--cyclo-over=12 \
-							--tests \
-							--exclude='TLS InsecureSkipVerify may be true.' \
-							--exclude='Use of unsafe calls should be audited' \
-							--deadline=300s ./...
+.PHONY: metalinter
+metalinter: $(if $(DOCKER), dockerbuild, deps)
+	$(if $(DOCKER), docker run --rm $(BUILD_CONTAINER)) gometalinter \
+		--vendor \
+		--concurrency=6 \
+		--cyclo-over=12 \
+		--tests \
+		--exclude='TLS InsecureSkipVerify may be true.' \
+		--exclude='Use of unsafe calls should be audited' \
+		--deadline=300s ./...
 
-gocov: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gocov test ./... -short -timeout=10m > $(PWD)/cov.json
+.PHONY: test
+test: fmttest metalinter gocov junit gorace
 
-gorace: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) go test -v -short -race -timeout=10m ./...
-
-artifacts: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm -v "$(CIRCLE_ARTIFACTS)":/output $(CONTAINERNAME)-build) gox -arch=amd64 -os="linux darwin windows" \
-												-output="/output/{{.Dir}}-$(VERSION)-{{.OS}}-{{.Arch}}" \
-												-ldflags="-X main.Version=$(VERSION)"
-
-coveralls: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm -v "$(PWD)":/coveralls $(CONTAINERNAME)-build) goveralls -service=circleci \
-											-gocovdata=/coveralls/cov.json \
-											-repotoken=$(COVERALLS_REPO_TOKEN) || true
-
-build: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":/build -e GOOS=$(GOOS) $(CONTAINERNAME)-build, env GOOS=$(GOOS)) go build -ldflags="-X main.Version=$(VERSION)" -o /build/mesos-dns
-
-buildstatic: $(if $(DOCKER), dockerbuild)
-	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":/build -e CGO_ENABLED=0 -e GOOS=$(GOOS) $(CONTAINERNAME)-build, env CGO_ENABLED=0 GOOS=$(GOOS)) go build -a -installsuffix cgo \
-																			-ldflags "-s -X main.Version=$(VERSION)" \
-																			-o /build/mesos-dns
-
+.PHONY: version
 version:
 	@echo "$(VERSION)"
-
-clean:
-	docker rmi $(CONTAINERNAME)-build || true
-	docker rmi $(CONTAINERNAME) || true
-
-help:
-	@echo "all - run all tests and compile mesos-dns"
-	@echo "artifacts - compiles the program using gox for linux darwin and windows platforms"
-	@echo "build - compiles the program, env GOOS can be set to specifiy platform"
-	@echo "buildstatic - compiles a statically linked program, env GOOS can be set to specify platform"
-	@echo "clean - remove mesos-dns and mesos-dns-build docker images"
-	@echo "coveralls - runs goveralls and uploads data to coveralls, env COVERALLS_REPO_TOKEN is needed"
-	@echo "dockerbuild - create mesos-dns-build docker image"
-	@echo "fmttest - runs gofmt, returns 0 for success, 1 for failure"
-	@echo "gocov - runs gocov"
-	@echo "gorace - runs go test with race detection enabled"
-	@echo "junit - runs go test and generates junit output"
-	@echo "metalinter - runs gometalinter"
-	@echo "test - runs fmttest and the various tests against the source code"
-	@echo "version - display current version"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,97 @@
+GOOS:=linux
+VERSION:=$(shell git describe --abbrev=4 --always --tags)
+NAME:=mesos-dns
+CONTAINERNAME:=$(NAME)
+CIRCLE_TEST_REPORTS?=$(PWD)
+CIRCLE_ARTIFACTS?=$(PWD)/build
+COVERALLS_REPO_TOKEN?="tokennotset"
+DOCKER?=
+
+all: $(if $(DOCKER), dockerbuild) test build
+
+deps:
+	go get -u github.com/kardianos/govendor
+	go get -u github.com/mitchellh/gox
+	go get -u github.com/alecthomas/gometalinter
+	go get -u github.com/axw/gocov/gocov
+	go get -u github.com/mattn/goveralls
+	go get -u github.com/jstemmer/go-junit-report
+	gometalinter --install
+	govendor sync
+	go install ./...
+	go test -i ./...
+
+dockerbuild:
+	docker build -t $(CONTAINERNAME)-build -f Dockerfile.test .
+
+test: fmttest metalinter gocov junit gorace
+
+## Ignore vendored dependencies
+## Return 1 if any files found that haven't been formatted
+fmttest: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gofmt -l . | \
+								awk '!/^vendor/ { print $0; err=1 }; END{ exit err }'
+
+junit: $(if $(DOCKER), dockerbuild)
+	mkdir -p $(CIRCLE_TEST_REPORTS)/junit
+	@# This seems odd, but if you attach stdin without attaching to an
+	@# output ( stdout or stderr ), the container runs in the background
+	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) go test -v -timeout=10m ./... | \
+	$(if $(DOCKER), docker run --rm -i -a stdin -a stdout -a stderr $(CONTAINERNAME)-build ) go-junit-report > $(CIRCLE_TEST_REPORTS)/junit/alltests.xml
+
+metalinter: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gometalinter \
+							--vendor \
+							--concurrency=6 \
+							--cyclo-over=12 \
+							--tests \
+							--exclude='TLS InsecureSkipVerify may be true.' \
+							--exclude='Use of unsafe calls should be audited' \
+							--deadline=300s ./...
+
+gocov: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) gocov test ./... -short -timeout=10m > $(PWD)/cov.json
+
+gorace: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm $(CONTAINERNAME)-build) go test -v -short -race -timeout=10m ./...
+
+artifacts: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm -v "$(CIRCLE_ARTIFACTS)":/output $(CONTAINERNAME)-build) gox -arch=amd64 -os="linux darwin windows" \
+												-output="/output/{{.Dir}}-$(VERSION)-{{.OS}}-{{.Arch}}" \
+												-ldflags="-X main.Version=$(VERSION)"
+
+coveralls: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)":/coveralls $(CONTAINERNAME)-build) goveralls -service=circleci \
+											-gocovdata=/coveralls/cov.json \
+											-repotoken=$(COVERALLS_REPO_TOKEN) || true
+
+build: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":/build -e GOOS=$(GOOS) $(CONTAINERNAME)-build, env GOOS=$(GOOS)) go build -ldflags="-X main.Version=$(VERSION)" -o /build/mesos-dns
+
+buildstatic: $(if $(DOCKER), dockerbuild)
+	$(if $(DOCKER), docker run --rm -v "$(PWD)/build":/build -e CGO_ENABLED=0 -e GOOS=$(GOOS) $(CONTAINERNAME)-build, env CGO_ENABLED=0 GOOS=$(GOOS)) go build -a -installsuffix cgo \
+																			-ldflags "-s -X main.Version=$(VERSION)" \
+																			-o /build/mesos-dns
+
+version:
+	@echo "$(VERSION)"
+
+clean:
+	docker rmi $(CONTAINERNAME)-build || true
+	docker rmi $(CONTAINERNAME) || true
+
+help:
+	@echo "all - run all tests and compile mesos-dns"
+	@echo "artifacts - compiles the program using gox for linux darwin and windows platforms"
+	@echo "build - compiles the program, env GOOS can be set to specifiy platform"
+	@echo "buildstatic - compiles a statically linked program, env GOOS can be set to specify platform"
+	@echo "clean - remove mesos-dns and mesos-dns-build docker images"
+	@echo "coveralls - runs goveralls and uploads data to coveralls, env COVERALLS_REPO_TOKEN is needed"
+	@echo "dockerbuild - create mesos-dns-build docker image"
+	@echo "fmttest - runs gofmt, returns 0 for success, 1 for failure"
+	@echo "gocov - runs gocov"
+	@echo "gorace - runs go test with race detection enabled"
+	@echo "junit - runs go test and generates junit output"
+	@echo "metalinter - runs gometalinter"
+	@echo "test - runs fmttest and the various tests against the source code"
+	@echo "version - display current version"

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ the same stability and compatibility guarantees as releases.
 All branches and pull requests are tested by [Circle-CI](https://circleci.com/gh/mesosphere/mesos-dns), which also
 outputs artifacts for Mac OS X, Windows, and Linux via cross-compilation.
 
-You will need [Go](https://golang.org/) *1.5* or later to build the project.
-All dependencies are vendored using `Godeps`. You must first install it in order to build from source.
+Builds can be done using [Go](https://golang.org/) *1.6.3* or later or through [Docker](https://www.docker.com/). 
+A Makefile is also available for your convenience.
 
 ```shell
-$ go get github.com/tools/godep
-$ godep go build ./...
+# Using go
+$ go build ./...
+# Using go via makefile
+$ make build
+# Using docker via makefile
+$ make build DOCKER=true
 ```
 
 ### Building for release
@@ -52,8 +56,17 @@ There are only very few users with access to the private key, and they also have
 
 
 ## Testing
+
+Builds can be done using [Go](https://golang.org/) *1.6.3* or later or through [Docker](https://www.docker.com/). 
+A Makefile is also available for your convenience.
+
 ```shell
-$ godep go test -race ./...
+# Using go
+$ go test -race ./...
+# Using go via makefile
+$ make gorace
+# Using docker via makefile
+$ make gorace DOCKER=true
 ```
 
 ## Documentation

--- a/circle.yml
+++ b/circle.yml
@@ -1,42 +1,15 @@
 machine:
-  pre:
-    - wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
-    - tar zxvf go1.6.2.linux-amd64.tar.gz
-  environment:
-    GOROOT: ${HOME}/go
-    GOPATH: ${HOME}/gopath
-    PATH: ${GOROOT}/bin:${GOPATH}/bin:${PATH}
-    GO15VENDOREXPERIMENT: 1
-  post:
-    - go version
   services:
+    - docker
 
 dependencies:
   pre:
-    - mkdir -p ${GOPATH}/src/github.com/mesosphere/mesos-dns
-    - go version
-    - go get github.com/kardianos/govendor
-    - go get github.com/mitchellh/gox
-    - go get github.com/alecthomas/gometalinter
-    - go get github.com/axw/gocov/gocov # https://github.com/golang/go/issues/6909
-    - go get github.com/mattn/goveralls
-    - go get github.com/jstemmer/go-junit-report
-    - sudo mount --bind $PWD $GOPATH/src/github.com/mesosphere/mesos-dns
     - git describe --tags |tee VERSION
     - gpg --yes --batch --import build/private.key
   override:
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && govendor sync
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && go install ./...
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && go test -i ./...
-    - gometalinter --install
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && gox -arch=amd64 -os="linux darwin windows" -output="${CIRCLE_ARTIFACTS}/{{.Dir}}-$(<VERSION)-{{.OS}}-{{.Arch}}" -ldflags="-X main.Version=$(<VERSION)"
+    - make artifacts DOCKER=true
     - if [ -n "$PASSPHRASE" ]; then for i in ${CIRCLE_ARTIFACTS}/*; do gpg --detach-sig --no-use-agent --yes --batch --passphrase=$PASSPHRASE -u mesos-dns --sign --armor $i; done; fi
 
 test:
   override:
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && gometalinter --vendor --concurrency=6 --cyclo-over=12 --tests --exclude='TLS InsecureSkipVerify may be true.' --exclude='Use of unsafe calls should be audited' --deadline=300s ./...
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && gocov test ./... -short -timeout=10m > ~/cov.json
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit && cd $GOPATH/src/github.com/mesosphere/mesos-dns && go test -v -timeout=10m ./... | go-junit-report > $CIRCLE_TEST_REPORTS/junit/alltests.xml
-    - cd $GOPATH/src/github.com/mesosphere/mesos-dns && go test -v -short -race -timeout=10m ./...
-  post:
-    - goveralls -service=circleci -gocovdata=~/cov.json -repotoken=$COVERALLS_REPO_TOKEN || true
+    - make test DOCKER=true


### PR DESCRIPTION
Part of work that was mentioned in #439

This adds support for using docker as a build environment. I've left the go version at 1.6.3 since 1.7 was just released last week. 

There are two dockerfiles included
- Dockerfile.build: This is a minimal container that can be used for running mesos-dns. It's a bit lacking currently as we have a consul wrapper shell script to pull down the mesos-dns config from consul, but I left those pieces out for a later PR.
- Dockerfile.test: This is the container that is used for the build environment ( running gofmt, go test )

The makefile is fairly minimal, if desired we can pull in additional commands from circle.yml.
