### PR TITLE
Adding in support for additional resolvers

### DIFF
--- a/factories/bogusconfig.json
+++ b/factories/bogusconfig.json
@@ -1,0 +1,6 @@
+#!/usr/bin/echo
+{
+This is not proper json
+}
+wtfbbq()[]
+

--- a/factories/validconfig.json
+++ b/factories/validconfig.json
@@ -1,0 +1,37 @@
+{
+    "Domain":              "testing",
+    "EnforceRFC952":       true,
+    "File":                "config.inception",
+    "IPSources":           ["host", "docker", "mesos", "rkt"],
+    "Masters":             ["127.0.0.1"],
+    "RefreshSeconds":      5,
+    "Backends": {
+        "builtin": {
+            "DNSOn":       true,
+            "Resolvers":   ["8.8.8.8", "8.8.4.4"],
+            "ExternalOn":  true,
+            "HTTPOn":      true,
+            "HTTPPort":    8080,
+            "Listener":    "127.0.0.1",
+            "Port":        15353,
+            "RecurseOn":   true,
+            "Timeout":     5,
+            "TTL":         5
+        },
+        "consul": {
+            "Address":     "127.0.0.1:8500",
+            "Datacenter":  "test",
+            "Scheme":      "http"
+        }
+    },
+    "StateTimeoutSeconds": 5,
+    "SOAExpire":           5,
+    "SOAMinttl":           5,
+    "SOAMname":            "dnsmenow.com",
+    "SOARefresh":          5,
+    "SOARetry":            5,
+    "SOARname":            "somebody@tech.me",
+    "SOASerial":           5,
+    "Zk":                  "yolozk.com",
+    "ZkDetectionTimeout":  5
+}

--- a/records/config.go
+++ b/records/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,28 +15,17 @@ import (
 	"github.com/mesosphere/mesos-dns/httpcli/basic"
 	"github.com/mesosphere/mesos-dns/httpcli/iam"
 	"github.com/mesosphere/mesos-dns/logging"
-	"github.com/miekg/dns"
 )
 
 // Config holds mesos dns configuration
 type Config struct {
 	// Refresh frequency: the frequency in seconds of regenerating records (default 60)
 	RefreshSeconds int
-	// Resolver port: port used to listen for slave requests (default 53)
-	Port int
-	// Timeout is the default connect/read/write timeout for outbound
-	// queries
-	Timeout int
 	// Timeout in seconds waiting for the master to return data from StateJson
 	StateTimeoutSeconds int
 	// Zookeeper Detection Timeout: how long in seconds to wait for Zookeeper to
 	// be initially responsive. Default is 30 and 0 means no timeout.
 	ZkDetectionTimeout int
-	// NOTE(tsenart): HTTPPort, DNSOn and HTTPOn have defined JSON keys for
-	// backwards compatibility with external API clients.
-	HTTPPort int `json:"HttpPort"`
-	// TTL: the TTL value used for SRV and A records (default 60)
-	TTL int32
 	// SOA record fields (see http://tools.ietf.org/html/rfc1035#page-18)
 	SOASerial  uint32 // initial version number (incremented on refresh)
 	SOARefresh uint32 // refresh interval
@@ -60,23 +48,14 @@ type Config struct {
 	File string
 	// Listen is the server DNS listener IP address
 	Listener string
-	// HTTPListen is the server HTTP listener IP address
-	HTTPListener string
-	// Value of RecursionAvailable for responses in Mesos domain
-	RecurseOn bool
-	// Enable serving DSN and HTTP requests
-	DNSOn  bool `json:"DnsOn"`
-	HTTPOn bool `json:"HttpOn"`
-	// Enable replies for external requests
-	ExternalOn bool
 	// EnforceRFC952 will enforce an older, more strict set of rules for DNS labels
 	EnforceRFC952 bool
-	// Enumeration enabled via the API enumeration endpoint
-	EnumerationOn bool
 	// Communicate with Mesos using HTTPS if set to true
 	MesosHTTPSOn bool
 	// CA certificate to use to verify Mesos Master certificate
 	CACertFile string
+	// Which backend resolvers to load
+	Backends map[string]interface{}
 
 	MesosCredentials basic.Credentials
 	// IAM Config File
@@ -94,10 +73,7 @@ func NewConfig() Config {
 	return Config{
 		ZkDetectionTimeout:  30,
 		RefreshSeconds:      60,
-		TTL:                 60,
 		Domain:              "mesos",
-		Port:                53,
-		Timeout:             5,
 		StateTimeoutSeconds: 300,
 		SOARname:            "root.ns1.mesos",
 		SOAMname:            "ns1.mesos",
@@ -105,37 +81,28 @@ func NewConfig() Config {
 		SOARetry:            600,
 		SOAExpire:           86400,
 		SOAMinttl:           60,
-		Resolvers:           []string{"8.8.8.8"},
-		Listener:            "0.0.0.0",
-		HTTPListener:        "0.0.0.0",
-		HTTPPort:            8123,
-		DNSOn:               true,
-		HTTPOn:              true,
-		ExternalOn:          true,
-		RecurseOn:           true,
 		IPSources:           []string{"netinfo", "mesos", "host"},
-		EnumerationOn:       true,
 		MesosAuthentication: httpcli.AuthNone,
 	}
 }
 
 // SetConfig instantiates a Config struct read in from config.json
 func SetConfig(cjson string) Config {
-	c, err := readConfig(cjson)
+	c, err := ReadConfig(cjson)
 	if err != nil {
 		logging.Error.Fatal(err)
 	}
 	logging.Verbose.Printf("config loaded from %q", c.File)
+
 	// validate and complete configuration file
 	err = validateEnabledServices(c)
 	if err != nil {
 		logging.Error.Fatalf("service validation failed: %v", err)
 	}
+
 	if err = validateMasters(c.Masters); err != nil {
 		logging.Error.Fatalf("Masters validation failed: %v", err)
 	}
-
-	c.initResolvers()
 
 	if err = validateIPSources(c.IPSources); err != nil {
 		logging.Error.Fatalf("IPSources validation failed: %v", err)
@@ -146,6 +113,11 @@ func SetConfig(cjson string) Config {
 	}
 
 	c.Domain = strings.ToLower(c.Domain)
+
+	// Default to builtin config if none have been specified
+	if c.Backends == nil {
+		c.Backends = map[string]interface{}{"builtin": nil}
+	}
 
 	c.initSOA()
 
@@ -182,17 +154,6 @@ func (c *Config) initMesosAuthentication() {
 	}
 }
 
-func (c *Config) initResolvers() {
-	if c.ExternalOn {
-		if len(c.Resolvers) == 0 {
-			c.Resolvers = GetLocalDNS()
-		}
-		if err := validateResolvers(c.Resolvers); err != nil {
-			logging.Error.Fatalf("Resolvers validation failed: %v", err)
-		}
-	}
-}
-
 func (c *Config) initSOA() {
 	// SOA record fields
 	c.SOARname = strings.TrimRight(strings.Replace(c.SOARname, "@", ".", -1), ".") + "."
@@ -200,7 +161,7 @@ func (c *Config) initSOA() {
 	c.SOASerial = uint32(time.Now().Unix())
 }
 
-func (c Config) log() {
+func (c *Config) log() {
 	// print configuration file
 	logging.Verbose.Println("Mesos-DNS configuration:")
 	logging.Verbose.Println("   - Masters: " + strings.Join(c.Masters, ", "))
@@ -208,15 +169,7 @@ func (c Config) log() {
 	logging.Verbose.Println("   - ZookeeperDetectionTimeout: ", c.ZkDetectionTimeout)
 	logging.Verbose.Println("   - RefreshSeconds: ", c.RefreshSeconds)
 	logging.Verbose.Println("   - Domain: " + c.Domain)
-	logging.Verbose.Println("   - Listener: " + c.Listener)
-	logging.Verbose.Println("   - HTTPListener: " + c.HTTPListener)
-	logging.Verbose.Println("   - Port: ", c.Port)
-	logging.Verbose.Println("   - DnsOn: ", c.DNSOn)
-	logging.Verbose.Println("   - TTL: ", c.TTL)
-	logging.Verbose.Println("   - Timeout: ", c.Timeout)
 	logging.Verbose.Println("   - StateTimeoutSeconds: ", c.StateTimeoutSeconds)
-	logging.Verbose.Println("   - Resolvers: " + strings.Join(c.Resolvers, ", "))
-	logging.Verbose.Println("   - ExternalOn: ", c.ExternalOn)
 	logging.Verbose.Println("   - SOAMname: " + c.SOAMname)
 	logging.Verbose.Println("   - SOARname: " + c.SOARname)
 	logging.Verbose.Println("   - SOASerial: ", c.SOASerial)
@@ -224,13 +177,9 @@ func (c Config) log() {
 	logging.Verbose.Println("   - SOARetry: ", c.SOARetry)
 	logging.Verbose.Println("   - SOAExpire: ", c.SOAExpire)
 	logging.Verbose.Println("   - SOAExpire: ", c.SOAMinttl)
-	logging.Verbose.Println("   - RecurseOn: ", c.RecurseOn)
-	logging.Verbose.Println("   - HttpPort: ", c.HTTPPort)
-	logging.Verbose.Println("   - HttpOn: ", c.HTTPOn)
 	logging.Verbose.Println("   - ConfigFile: ", c.File)
 	logging.Verbose.Println("   - EnforceRFC952: ", c.EnforceRFC952)
 	logging.Verbose.Println("   - IPSources: ", c.IPSources)
-	logging.Verbose.Println("   - EnumerationOn", c.EnumerationOn)
 	logging.Verbose.Println("   - MesosHTTPSOn", c.MesosHTTPSOn)
 	logging.Verbose.Println("   - CACertFile", c.CACertFile)
 	logging.Verbose.Println("   - MesosAuthentication: ", c.MesosAuthentication)
@@ -247,6 +196,17 @@ func (c Config) log() {
 		if c.IAMConfigFile != "" {
 			logging.Error.Println("Warning! IAMConfigFile is set, but " +
 				"MesosAuthentication is set to none. This is probably not intentional")
+		}
+	}
+
+	// print individual configurations for resolvers
+	logging.Verbose.Println("   - Backends:")
+	for k, v := range c.Backends {
+		logging.Verbose.Printf("     - %s:\n", k)
+		if m, ok := v.(map[string]interface{}); ok {
+			for key, val := range m {
+				logging.Verbose.Printf("       - %s: %+v\n", key, val)
+			}
 		}
 	}
 }
@@ -274,7 +234,8 @@ func readCACertFile(caCertFile string) (caPool *x509.CertPool, err error) {
 	return
 }
 
-func readConfig(file string) (*Config, error) {
+// ReadConfig reads in a config file and unmarshals it as a Config struct
+func ReadConfig(file string) (*Config, error) {
 	c := NewConfig()
 
 	workingDir := "."
@@ -307,60 +268,4 @@ func unique(ss []string) []string {
 		}
 	}
 	return out
-}
-
-// GetLocalDNS returns the first nameserver in /etc/resolv.conf
-// Used for non-Mesos queries.
-func GetLocalDNS() []string {
-	conf, err := dns.ClientConfigFromFile("/etc/resolv.conf")
-	if err != nil {
-		logging.Error.Fatalf("%v", err)
-	}
-
-	return nonLocalAddies(conf.Servers)
-}
-
-// Returns non-local nameserver entries
-func nonLocalAddies(cservers []string) []string {
-	bad := localAddies()
-
-	good := []string{}
-
-	for i := 0; i < len(cservers); i++ {
-		local := false
-		for x := 0; x < len(bad); x++ {
-			if cservers[i] == bad[x] {
-				local = true
-			}
-		}
-
-		if !local {
-			good = append(good, cservers[i])
-		}
-	}
-
-	return good
-}
-
-// Returns an array of local ipv4 addresses
-func localAddies() []string {
-	addies, err := net.InterfaceAddrs()
-	if err != nil {
-		logging.Error.Println(err)
-	}
-
-	bad := []string{}
-
-	for i := 0; i < len(addies); i++ {
-		ip, _, err := net.ParseCIDR(addies[i].String())
-		if err != nil {
-			logging.Error.Println(err)
-		}
-		t4 := ip.To4()
-		if t4 != nil {
-			bad = append(bad, t4.String())
-		}
-	}
-
-	return bad
 }

--- a/records/config_test.go
+++ b/records/config_test.go
@@ -1,27 +1,13 @@
 package records
 
 import (
+	"reflect"
 	"testing"
 )
-
-func TestNonLocalAddies(t *testing.T) {
-	nlocal := []string{"127.0.0.1"}
-	addies := nonLocalAddies(nlocal)
-
-	for i := 0; i < len(addies); i++ {
-		if "127.0.0.1" == addies[i] {
-			t.Error("finding a local address")
-		}
-	}
-}
 
 func TestNewConfigValidates(t *testing.T) {
 	c := NewConfig()
 	err := validateIPSources(c.IPSources)
-	if err != nil {
-		t.Error(err)
-	}
-	err = validateResolvers(c.Resolvers)
 	if err != nil {
 		t.Error(err)
 	}
@@ -37,5 +23,32 @@ func TestNewConfigValidates(t *testing.T) {
 	err = validateEnabledServices(&c)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+type testingFile struct {
+	file   string
+	result map[string]interface{}
+	valid  bool
+}
+
+func TestReadConfig(t *testing.T) {
+	for _, tc := range []testingFile{
+		{"/does/not/exist", nil, false},
+		{"../factories/bogusconfig.json", nil, false},
+		{"../factories/emptyconfig.json", nil, false},
+		{"../factories/validconfig.json", nil, true},
+	} {
+		c, err := ReadConfig(tc.file)
+		if err != nil && tc.valid {
+			t.Fatal("Error returned: ", err)
+		}
+
+		if tc.result != nil {
+			for k, v := range tc.result {
+				x := reflect.ValueOf(&c).Elem()
+				t.Logf("%s: %q == %q", k, v, x.FieldByName(k))
+			}
+		}
 	}
 }

--- a/records/validation.go
+++ b/records/validation.go
@@ -6,9 +6,6 @@ import (
 )
 
 func validateEnabledServices(c *Config) error {
-	if !c.DNSOn && !c.HTTPOn {
-		return fmt.Errorf("Either DNS or HTTP server should be on")
-	}
 	if len(c.Masters) == 0 && c.Zk == "" {
 		return fmt.Errorf("specify mesos masters or zookeeper in config.json")
 	}
@@ -38,28 +35,6 @@ func validateMasters(ms []string) error {
 			return fmt.Errorf("duplicate master specified: %v", ms[i])
 		}
 		valid[m] = struct{}{}
-	}
-	return nil
-}
-
-// validateResolvers checks that each resolver in the list is a properly formatted IP address.
-// duplicate resolvers in the list are not allowed.
-// returns nil if the resolver list is empty, or else all resolvers in the list are valid.
-func validateResolvers(rs []string) error {
-	if len(rs) == 0 {
-		return nil
-	}
-	ips := make(map[string]struct{}, len(rs))
-	for _, r := range rs {
-		ip := net.ParseIP(r)
-		if ip == nil {
-			return fmt.Errorf("illegal IP specified for resolver %q", r)
-		}
-		ipstr := ip.String()
-		if _, found := ips[ipstr]; found {
-			return fmt.Errorf("duplicate resolver IP specified: %v", r)
-		}
-		ips[ipstr] = struct{}{}
 	}
 	return nil
 }

--- a/records/validation_test.go
+++ b/records/validation_test.go
@@ -29,26 +29,6 @@ func TestValidateMasters(t *testing.T) {
 	}
 }
 
-func TestValidateResolvers(t *testing.T) {
-	for i, tc := range []validationTest{
-		{nil, true},
-		{[]string{}, true},
-		{[]string{""}, false},
-		{[]string{"", ""}, false},
-		{[]string{"a"}, false},
-		{[]string{"a", "b"}, false},
-		{[]string{"1.2.3.4"}, true},
-		{[]string{"1.2.3.4.5"}, false},
-		{[]string{"1.2.3.4", "1.2.3.4"}, false},
-		{[]string{"1.2.3.4", "5.6.7.8"}, true},
-		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"}, true},
-		{[]string{"2001:db8:3c4d:15::1a2f:1a2b"}, true},
-		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
-	} {
-		validate(t, i+1, tc, validateResolvers)
-	}
-}
-
 type validationTest struct {
 	in    []string
 	valid bool

--- a/resolvers/builtin/config.go
+++ b/resolvers/builtin/config.go
@@ -1,0 +1,124 @@
+package builtin
+
+import (
+	"net"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/miekg/dns"
+)
+
+// Config holds the specific backend configuration for the builtin backend
+type Config struct {
+	// Enable serving DNS requests
+	DNSOn bool `json:"DnsOn"`
+	// Enable replies for external requests
+	ExternalOn bool
+	// Enable serving HTTP requests
+	HTTPOn bool `json:"HttpOn"`
+	// NOTE(tsenart): HTTPPort, DNSOn and HTTPOn have defined JSON keys for
+	// backwards compatibility with external API clients.
+	HTTPPort int `json:"HttpPort"`
+	// HTTPListen is the server HTTP listener IP address
+	HTTPListener string
+	// ListenAddr is the server listener address
+	Listener string
+	// Resolver port: port used to listen for slave requests (default 53)
+	Port int
+	// Value of RecursionAvailable for responses in Mesos domain
+	RecurseOn bool
+	// External DNS servers: IP address(es) of DNS server(s) for unauthoritative queries
+	ExternalDNS []string
+	// Timeout is the default connect/read/write timeout for outbound
+	// queries
+	Timeout int
+	// TTL: the TTL value used for SRV and A records (default 60)
+	TTL int32
+	// Enumeration enabled via the API enumeration endpoint
+	EnumerationOn bool
+}
+
+// NewConfig return the default config of the resolver
+func NewConfig() *Config {
+	c := &Config{
+		DNSOn:         true,
+		ExternalOn:    true,
+		HTTPOn:        true,
+		HTTPPort:      8123,
+		HTTPListener:  "0.0.0.0",
+		Listener:      "0.0.0.0",
+		Port:          53,
+		RecurseOn:     true,
+		Timeout:       5,
+		TTL:           60,
+		EnumerationOn: true,
+	}
+
+	return c
+}
+
+func (c *Config) initResolver() {
+	if c.ExternalOn {
+		if len(c.ExternalDNS) == 0 {
+			c.ExternalDNS = GetLocalDNS()
+		}
+		if err := validateExternalDNS(c.ExternalDNS); err != nil {
+			logging.Error.Fatalf("Resolvers validation failed: %v", err)
+		}
+	}
+}
+
+// GetLocalDNS returns the first nameserver in /etc/resolv.conf
+// Used for non-Mesos queries.
+func GetLocalDNS() []string {
+	conf, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		logging.Error.Fatalf("%v", err)
+	}
+
+	return nonLocalAddies(conf.Servers)
+}
+
+// Returns non-local nameserver entries
+func nonLocalAddies(cservers []string) []string {
+	bad := localAddies()
+
+	good := []string{}
+
+	for i := 0; i < len(cservers); i++ {
+		local := false
+		for x := 0; x < len(bad); x++ {
+			if cservers[i] == bad[x] {
+				local = true
+			}
+		}
+
+		if !local {
+			good = append(good, cservers[i])
+		}
+	}
+
+	return good
+}
+
+// Returns an array of local ipv4 addresses
+func localAddies() []string {
+	addies, err := net.InterfaceAddrs()
+	if err != nil {
+		logging.Error.Println(err)
+	}
+
+	bad := []string{}
+
+	for i := 0; i < len(addies); i++ {
+		ip, _, err := net.ParseCIDR(addies[i].String())
+		if err != nil {
+			logging.Error.Println(err)
+		}
+		t4 := ip.To4()
+		if t4 != nil {
+			bad = append(bad, t4.String())
+		}
+	}
+
+	return bad
+}

--- a/resolvers/builtin/config_test.go
+++ b/resolvers/builtin/config_test.go
@@ -1,0 +1,35 @@
+package builtin
+
+import (
+	"testing"
+)
+
+func TestNonLocalAddies(t *testing.T) {
+	nlocal := []string{"127.0.0.1"}
+	addies := nonLocalAddies(nlocal)
+
+	for i := 0; i < len(addies); i++ {
+		if "127.0.0.1" == addies[i] {
+			t.Error("finding a local address")
+		}
+	}
+}
+
+func TestNewConfigValidate(t *testing.T) {
+	c := NewConfig()
+	err := validateExternalDNS(c.ExternalDNS)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = validateEnabledServices(c)
+	if err != nil {
+		t.Error(err)
+	}
+	c.HTTPOn = false
+	c.DNSOn = false
+	err = validateEnabledServices(c)
+	if err == nil {
+		t.Error("expected error because DNS and HTTP server are disabled")
+	}
+}

--- a/resolvers/builtin/rand.go
+++ b/resolvers/builtin/rand.go
@@ -1,4 +1,4 @@
-package resolver
+package builtin
 
 import (
 	"math/rand"

--- a/resolvers/builtin/validation.go
+++ b/resolvers/builtin/validation.go
@@ -1,0 +1,35 @@
+package builtin
+
+import (
+	"fmt"
+	"net"
+)
+
+func validateEnabledServices(c *Config) error {
+	if !c.DNSOn && !c.HTTPOn {
+		return fmt.Errorf("Either DNS or HTTP server should be on")
+	}
+	return nil
+}
+
+// validateExternalDNS checks that each remote server's IP in the list is a properly
+// formatted IP address. Duplicate IPs in the list are not allowed.
+// returns nil if the remote server list is empty, or else all IPs in the list are valid.
+func validateExternalDNS(rs []string) error {
+	if len(rs) == 0 {
+		return nil
+	}
+	ips := make(map[string]struct{}, len(rs))
+	for _, r := range rs {
+		ip := net.ParseIP(r)
+		if ip == nil {
+			return fmt.Errorf("illegal IP specified for remote server %q", r)
+		}
+		ipstr := ip.String()
+		if _, found := ips[ipstr]; found {
+			return fmt.Errorf("duplicate remote IP specified: %v", r)
+		}
+		ips[ipstr] = struct{}{}
+	}
+	return nil
+}

--- a/resolvers/builtin/validation_test.go
+++ b/resolvers/builtin/validation_test.go
@@ -1,0 +1,41 @@
+package builtin
+
+import (
+	"testing"
+)
+
+func TestValidateExternalDNS(t *testing.T) {
+	for i, tc := range []validationTest{
+		{nil, true},
+		{[]string{}, true},
+		{[]string{""}, false},
+		{[]string{"", ""}, false},
+		{[]string{"a"}, false},
+		{[]string{"a", "b"}, false},
+		{[]string{"1.2.3.4"}, true},
+		{[]string{"1.2.3.4.5"}, false},
+		{[]string{"1.2.3.4", "1.2.3.4"}, false},
+		{[]string{"1.2.3.4", "5.6.7.8"}, true},
+		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"}, true},
+		{[]string{"2001:db8:3c4d:15::1a2f:1a2b"}, true},
+		{[]string{"2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b", "2001:db8:3c4d:15::1a2f:1a2b"}, false},
+	} {
+		validate(t, i+1, tc, validateExternalDNS)
+	}
+}
+
+type validationTest struct {
+	in    []string
+	valid bool
+}
+
+func validate(t *testing.T, i int, tc validationTest, f func([]string) error) {
+	switch err := f(tc.in); {
+	case (err == nil && tc.valid) || (err != nil && !tc.valid):
+		return // valid
+	case tc.valid:
+		t.Fatalf("test %d failed, unexpected error validating remote DNS server %v: %v", i, tc.in, err)
+	default:
+		t.Fatalf("test %d failed, expected validation error for ExternalDNS(%d) %v", i, len(tc.in), tc.in)
+	}
+}

--- a/resolvers/resolvers.go
+++ b/resolvers/resolvers.go
@@ -1,0 +1,40 @@
+package resolvers
+
+import (
+	"strings"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+	"github.com/mesosphere/mesos-dns/resolvers/builtin"
+	"github.com/mesosphere/mesos-dns/utils"
+)
+
+// The resolver interface is the means by which additional backends can be added
+// Resolver wraps the Reload method that takes a RecordGenerator struct. The
+// RecordGenerator contains the original and parsed state.json information. The
+// Reload method is called on a periodic basis with updated state information.
+type Resolver interface {
+	Reload(rg *records.RecordGenerator)
+}
+
+// New initializes all configured backends and returns a slice of all the
+// configured backends
+func New(errch chan error, rg *records.RecordGenerator, version string) []Resolver {
+	var resolvers []Resolver
+
+	for k, v := range rg.Config.Backends {
+		// Each backend receives their config as type interface{} or nil.
+		switch strings.ToLower(k) {
+		case "builtin":
+			conf := builtin.NewConfig()
+			utils.Merge(v, conf)
+			// Print out here after the merge to show the merged config
+			logging.VeryVerbose.Printf("Initializing resolver %s with config %+v\n", k, conf)
+			resolvers = append(resolvers, builtin.New(version, errch, conf, rg))
+		default:
+			logging.Verbose.Printf("Unrecognized resolver %s", k)
+		}
+	}
+
+	return resolvers
+}

--- a/resolvers/resolvers_test.go
+++ b/resolvers/resolvers_test.go
@@ -1,0 +1,77 @@
+package resolvers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records"
+)
+
+func TestResolvers(t *testing.T) {
+	t.Log("Attempting to read config from ../factories/validconfig.json")
+	c, err := records.ReadConfig("../factories/validconfig.json")
+	if err != nil {
+		t.Fatal("Error reading config file:", err)
+	}
+
+	// Initialize logging
+	logging.SetupLogs()
+
+	// First test with default values
+	t.Log("Initializing Resolvers with default config")
+	if err := CreateResolvers(c); err != nil {
+		t.Fatalf("Error returned from resolvers: %v", err)
+	}
+
+	tcs := []testConfig{
+		{nil, true},
+		{map[string]interface{}{
+			"DNSOn":      false,
+			"ExternalOn": false,
+			"HTTPOn":     false},
+			true},
+		{map[string]interface{}{
+			"NotReal": "fake, fake",
+			"Port":    25353},
+			false},
+	}
+
+	for i, tc := range tcs {
+		t.Logf("Initializitng iteration %v with 'builtin' config %v", i, tc.Settings)
+		if tc.Settings != nil {
+			c.Backends = map[string]interface{}{"builtin": tc.Settings}
+		} else {
+			c.Backends = nil
+		}
+		if err := CreateResolvers(c); err != nil {
+			t.Fatalf("Error returned from resolvers: %v", err)
+		}
+	}
+}
+
+type testConfig struct {
+	Settings interface{}
+	Valid    bool
+}
+
+func CreateResolvers(config *records.Config) error {
+	errch := make(chan error)
+	version := "test"
+
+	rg := records.NewRecordGenerator(records.WithConfig(*config))
+	rg.Config = *config
+
+	// Initialization errors should show in well under 10 seconds
+	timeout := time.NewTicker(time.Second * time.Duration(10))
+	New(errch, rg, version)
+
+	for {
+		select {
+		case <-timeout.C:
+			return nil
+		case err := <-errch:
+			return err
+		}
+	}
+}

--- a/utils/merge.go
+++ b/utils/merge.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mesosphere/mesos-dns/logging"
+)
+
+// Merge attempts to merge two config structs together
+func Merge(data interface{}, config interface{}) {
+	if m, ok := data.(map[string]interface{}); ok {
+		for k, v := range m {
+			err := SetField(config, k, v)
+			// May want to do more than just log these errors
+			if err != nil {
+				logging.Verbose.Printf("Error merging config key %v: %v\n", k, err)
+			}
+		}
+	}
+}
+
+// SetField is a helper function for merging provided key/value with a struct
+func SetField(obj interface{}, name string, value interface{}) error {
+	structValue := reflect.ValueOf(obj)
+	structFieldValue := reflect.Indirect(structValue).FieldByName(name)
+
+	// Check if field exists
+	if !structFieldValue.IsValid() {
+		return fmt.Errorf("No such field: %s in obj", name)
+	}
+
+	// Check if field is settable
+	if !structFieldValue.CanSet() {
+		return fmt.Errorf("Cannot set %s field value", name)
+	}
+
+	structFieldType := structFieldValue.Type()
+	val := reflect.ValueOf(value)
+	if structFieldType != val.Type() {
+		// JSON converts all numbers to float64
+		switch val.Kind().String() {
+		case "float64":
+			newVal, err := ConvertNum(val.Float(), obj, name)
+			if err != nil {
+				return err
+			}
+			structFieldValue.Set(reflect.ValueOf(newVal))
+		case "slice":
+			// slice is a tricky one. Sticking to float64 and strings for now
+			if v, ok := value.([]float64); ok {
+				structFieldValue.Set(reflect.ValueOf(v))
+			} else if v, ok := value.([]string); ok {
+				structFieldValue.Set(reflect.ValueOf(v))
+			}
+		default:
+			return fmt.Errorf("Passed value (type %s) cannot be used for field (type %s)", val.Type(), structFieldType)
+		}
+	} else {
+		structFieldValue.Set(val)
+	}
+
+	return nil
+}
+
+// ConvertNum is a helper function to determine the correct numeric type for a
+// config struct value
+func ConvertNum(val float64, obj interface{}, name string) (interface{}, error) {
+	// This is the same reflection process from SetField()
+	structValue := reflect.ValueOf(obj)
+	structFieldValue := reflect.Indirect(structValue).FieldByName(name)
+
+	switch i := structFieldValue.Interface().(type) {
+	case int:
+		return int(val), nil
+	case uint8:
+		return uint8(val), nil
+	case uint16:
+		return uint16(val), nil
+	case uint32:
+		return uint32(val), nil
+	case uint64:
+		return uint64(val), nil
+	case int8:
+		return int8(val), nil
+	case int16:
+		return int16(val), nil
+	case int32:
+		return int32(val), nil
+	case int64:
+		return int64(val), nil
+	case float32:
+		return float32(val), nil
+	case float64:
+		return val, nil
+	default:
+		return nil, fmt.Errorf("Unexpected type found for field %s in obj: %s", name, reflect.TypeOf(i))
+	}
+}

--- a/utils/util.go
+++ b/utils/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package utils
 
 import (
 	"fmt"

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
Part of work that was mentioned in #439

This adds in the framework for extending mesos-dns to publish to an external source. The intent behind this is to provide a Resolver interface that consumes a RecordGenerator struct. The RecordGenerator contains all the necessary records and metadata for an external source to construct the necessary records. 

As part of this work, the existing resolver has been renamed to builtin and related configs have been moved as well. 
