### PR TITLE
Serve PTR records for unambiguous tasks

### DIFF
--- a/dnstest/message.go
+++ b/dnstest/message.go
@@ -70,6 +70,14 @@ func A(hdr dns.RR_Header, ip net.IP) *dns.A {
 	}
 }
 
+// PTR returns a PTR record set with the given arguments.
+func PTR(hdr dns.RR_Header, ptr string) *dns.PTR {
+	return &dns.PTR{
+		Hdr: hdr,
+		Ptr: ptr,
+	}
+}
+
 // SRV returns a SRV record set with the given arguments.
 func SRV(hdr dns.RR_Header, target string, port, priority, weight uint16) *dns.SRV {
 	return &dns.SRV{

--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -28,6 +28,7 @@ The configuration file should include the following fields:
   "timeout": 5, 
   "httpon": true,
   "dnson": true,
+  "reversednson": false,
   "httpport": 8123,
   "externalon": true,
   "listener": "10.101.160.16",
@@ -84,6 +85,13 @@ It is sufficient to specify just one of the `zk` or `masters` field. If both are
 `dnson` is a boolean field that controls whether Mesos-DNS listens for DNS requests or not. The default value is `true`. 
 
 `httpon` is a boolean field that controls whether Mesos-DNS listens for HTTP requests or not. The default value is `true`. 
+
+`reversednson` is a boolean field that controls whether Mesos-DNS acts as an
+authoritative nameserver for the in-addr.arpa and ip6.arpa domains, returning
+unambiguous PTR records to tasks dynamically. Enabling this option will turn
+off the previous default of forwarding reverse DNS lookups, which could break
+many set-ups. It is recommended only to use this experimental feature if you
+know what you are doing.
 
 `httpport` is the port number that Mesos-DNS monitors for incoming HTTP requests. The default value is `8123`.
 

--- a/docs/docs/naming.md
+++ b/docs/docs/naming.md
@@ -99,6 +99,14 @@ The following table illustrates the rules that govern SRV generation:
 |				   |yes | yes  	|{task}.framework.domain       | di-port   | container-ip |
 |_{task}._{proto}.framework.slave.domain |n/a | n/a |{task}.framework.slave.domain | host-port | slave-ip |
 
+# PTR records (Experimental, Reverse DNS)
+
+Mesos-DNS can behave as an authorative server for the ip6.arpa and the
+in-addr.arpa zones, providing reverse DNS resolution in the form of PTR records
+for non-ambiguous task records.
+
+This is enabled with the `reversednson` configuration option.
+
 ## Other Records
 
 Mesos-DNS generates a few special records:

--- a/records/config.go
+++ b/records/config.go
@@ -66,8 +66,9 @@ type Config struct {
 	HTTPListener string
 	// Value of RecursionAvailable for responses in Mesos domain
 	RecurseOn bool
-	// Enable serving DSN and HTTP requests
+	// Enable serving DNS, reverse DNS, and HTTP requests
 	DNSOn  bool `json:"DnsOn"`
+	ReverseDNSOn bool `json:"ReverseDnsOn"`
 	HTTPOn bool `json:"HttpOn"`
 	// Enable replies for external requests
 	ExternalOn bool

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -130,6 +130,25 @@ func runHandlers() error {
 					A(RRHeader("chronos.marathon.mesos.", dns.TypeA, 60),
 						net.ParseIP("1.2.3.11")))),
 		},
+		{ // PTR, unique
+			res.HandleMesos,
+			Message(
+				Question("12.3.2.1.in-addr.arpa.", dns.TypePTR),
+				Header(true, dns.RcodeSuccess),
+				Answers(
+					PTR(RRHeader("12.3.2.1.in-addr.arpa.", dns.TypePTR, 60),
+						"reviewbot.marathon.mesos."),
+					)),
+		},
+		{ // PTR, multiple results, ambiguous
+			res.HandleMesos,
+			Message(
+				Question("11.3.2.1.in-addr.arpa.", dns.TypePTR),
+				Header(true, dns.RcodeNameError),
+				NSs(
+					SOA(RRHeader("11.3.2.1.in-addr.arpa.", dns.TypeSOA, 60),
+						"ns1.mesos", "root.ns1.mesos", 60))),
+		},
 		{
 			res.HandleMesos,
 			Message(


### PR DESCRIPTION
Hi, we (a team at Commonwealth Bank) are trying to roll out a HDFS cluster on top of Mesos. This seems to require reverse DNS to be properly configured for tasks, and this seemed the most convenient place to add PTR records.

This patch is currently only unit tested, I'll be integration testing tomorrow.

This may be of interest to #286 and #67 (closed).
