### PR TITLE
resolver: make setting of the Truncate bit configurable

### DIFF
--- a/records/config.go
+++ b/records/config.go
@@ -77,6 +77,11 @@ type Config struct {
 	// SetTruncateBit when `false` ensures responses never have the Truncate bit set even
 	// if they were truncated. When `true` any message that gets truncated will have the
 	// Truncate bit set.
+	// Compliant clients that receive truncated responses will retry the request
+	// over TCP. Some non-compliant clients simply cannot handle truncated responses at all.
+	// Disabling this option causes mesos-dns to behave in a non-compliant way. It exists
+	// only as a workaround for non-compliant clients and users who cannot tolerate the
+	// latency added by the standard TCP fallback.
 	SetTruncateBit bool
 	// Enumeration enabled via the API enumeration endpoint
 	EnumerationOn bool

--- a/records/config.go
+++ b/records/config.go
@@ -74,6 +74,10 @@ type Config struct {
 	ExternalOn bool
 	// EnforceRFC952 will enforce an older, more strict set of rules for DNS labels
 	EnforceRFC952 bool
+	// SetTruncateBit when `false` ensures responses never have the Truncate bit set even
+	// if they were truncated. When `true` any message that gets truncated will have the
+	// Truncate bit set.
+	SetTruncateBit bool
 	// Enumeration enabled via the API enumeration endpoint
 	EnumerationOn bool
 	// Communicate with Mesos using HTTPS if set to true
@@ -123,6 +127,7 @@ func NewConfig() Config {
 		DNSOn:               true,
 		HTTPOn:              true,
 		ExternalOn:          true,
+		SetTruncateBit:      true,
 		RecurseOn:           true,
 		IPSources:           []string{"netinfo", "mesos", "host"},
 		EnumerationOn:       true,
@@ -272,6 +277,7 @@ func (c Config) log() {
 	logging.Verbose.Println("   - HttpOn: ", c.HTTPOn)
 	logging.Verbose.Println("   - ConfigFile: ", c.File)
 	logging.Verbose.Println("   - EnforceRFC952: ", c.EnforceRFC952)
+	logging.Verbose.Println("   - SetTruncateBit: ", c.SetTruncateBit)
 	logging.Verbose.Println("   - IPSources: ", c.IPSources)
 	logging.Verbose.Println("   - EnumerationOn", c.EnumerationOn)
 	logging.Verbose.Println("   - MesosHTTPSOn", c.MesosHTTPSOn)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -485,17 +485,15 @@ func truncate(m *dns.Msg, udp bool, setTruncateBit bool) *dns.Msg {
 		// Dropping the extra records shrunk the message down sufficiently.
 		return m
 	}
-	answers := m.Answer[:]
+	answers := m.Answer
 	search := func(n int) bool {
-		m.Answer = answers[:n]
-		return m.Len() > max
+		// we shave answers from the back of the slice
+		// until we find the point where m.Len is < max.
+		m.Answer = answers[:len(answers)-n]
+		return m.Len() < max
 	}
-	limit := sort.Search(len(answers), search)
-	if limit > 0 {
-		m.Answer = answers[:limit-1]
-	} else {
-		m.Answer = answers[:0]
-	}
+	drop := sort.Search(len(answers), search)
+	m.Answer = answers[:len(answers)-drop]
 	return m
 }
 


### PR DESCRIPTION
Setting the Truncate bit in the DNS message when it is truncated is now configurable.

The default behaviour is to set the Truncate bit when appropriate.

When this option is set to false the Truncate bit will be unset in all DNS responses.

This is non-compliant behaviour but we support it for cases where clients are also non-compliant.