### PR TITLE
Bump github.com/miekg/dns to 99f84ae56e75126dd77e5de4fae2ea034a468ca1

### DIFF
--- a/vendor/github.com/miekg/dns/.travis.yml
+++ b/vendor/github.com/miekg/dns/.travis.yml
@@ -1,7 +1,13 @@
 language: go
 sudo: false
 go:
-  - 1.5
   - 1.6
+  - 1.7
+
+before_install:
+  # don't use the miekg/dns when testing forks
+  - mkdir -p $GOPATH/src/github.com/miekg
+  - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
+
 script:
   - go test -race -v -bench=.

--- a/vendor/github.com/miekg/dns/README.md
+++ b/vendor/github.com/miekg/dns/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/miekg/dns.svg?branch=master)](https://travis-ci.org/miekg/dns)
+[![](https://godoc.org/github.com/miekg/dns?status.svg)](https://godoc.org/github.com/miekg/dns)
 
 # Alternative (more granular) approach to a DNS library
 
@@ -12,7 +13,7 @@ can build servers and resolvers with it.
 
 We try to keep the "master" branch as sane as possible and at the bleeding edge
 of standards, avoiding breaking changes wherever reasonable. We support the last
-two versions of Go, currently: 1.5 and 1.6.
+two versions of Go, currently: 1.6 and 1.7.
 
 # Goals
 
@@ -50,6 +51,9 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://dnslookup.org
 * https://github.com/looterz/grimd
 * https://github.com/phamhongviet/serf-dns
+* https://github.com/mehrdadrad/mylg
+* https://github.com/bamarni/dockness
+* https://github.com/fffaraz/microdns
 
 Send pull request if you want to be listed here.
 

--- a/vendor/github.com/miekg/dns/client.go
+++ b/vendor/github.com/miekg/dns/client.go
@@ -39,7 +39,7 @@ type Client struct {
 }
 
 // Exchange performs a synchronous UDP query. It sends the message m to the address
-// contained in a and waits for an reply. Exchange does not retry a failed query, nor
+// contained in a and waits for a reply. Exchange does not retry a failed query, nor
 // will it fall back to TCP in case of truncation.
 // See client.Exchange for more information on setting larger buffer sizes.
 func Exchange(m *Msg, a string) (r *Msg, err error) {
@@ -93,8 +93,8 @@ func ExchangeConn(c net.Conn, m *Msg) (r *Msg, err error) {
 	return r, err
 }
 
-// Exchange performs an synchronous query. It sends the message m to the address
-// contained in a and waits for an reply. Basic use pattern with a *dns.Client:
+// Exchange performs a synchronous query. It sends the message m to the address
+// contained in a and waits for a reply. Basic use pattern with a *dns.Client:
 //
 //	c := new(dns.Client)
 //	in, rtt, err := c.Exchange(message, "127.0.0.1:53")

--- a/vendor/github.com/miekg/dns/dane.go
+++ b/vendor/github.com/miekg/dns/dane.go
@@ -1,0 +1,44 @@
+package dns
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"io"
+)
+
+// CertificateToDANE converts a certificate to a hex string as used in the TLSA or SMIMEA records.
+func CertificateToDANE(selector, matchingType uint8, cert *x509.Certificate) (string, error) {
+	switch matchingType {
+	case 0:
+		switch selector {
+		case 0:
+			return hex.EncodeToString(cert.Raw), nil
+		case 1:
+			return hex.EncodeToString(cert.RawSubjectPublicKeyInfo), nil
+		}
+	case 1:
+		h := sha256.New()
+		switch selector {
+		case 0:
+			io.WriteString(h, string(cert.Raw))
+			return hex.EncodeToString(h.Sum(nil)), nil
+		case 1:
+			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
+			return hex.EncodeToString(h.Sum(nil)), nil
+		}
+	case 2:
+		h := sha512.New()
+		switch selector {
+		case 0:
+			io.WriteString(h, string(cert.Raw))
+			return hex.EncodeToString(h.Sum(nil)), nil
+		case 1:
+			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
+			return hex.EncodeToString(h.Sum(nil)), nil
+		}
+	}
+	return "", errors.New("dns: bad MatchingType or Selector")
+}

--- a/vendor/github.com/miekg/dns/defaults.go
+++ b/vendor/github.com/miekg/dns/defaults.go
@@ -102,11 +102,11 @@ func (dns *Msg) SetAxfr(z string) *Msg {
 // SetTsig appends a TSIG RR to the message.
 // This is only a skeleton TSIG RR that is added as the last RR in the
 // additional section. The Tsig is calculated when the message is being send.
-func (dns *Msg) SetTsig(z, algo string, fudge, timesigned int64) *Msg {
+func (dns *Msg) SetTsig(z, algo string, fudge uint16, timesigned int64) *Msg {
 	t := new(TSIG)
 	t.Hdr = RR_Header{z, TypeTSIG, ClassANY, 0, 0}
 	t.Algorithm = algo
-	t.Fudge = 300
+	t.Fudge = fudge
 	t.TimeSigned = uint64(timesigned)
 	t.OrigId = dns.Id
 	dns.Extra = append(dns.Extra, t)

--- a/vendor/github.com/miekg/dns/dnssec_keyscan.go
+++ b/vendor/github.com/miekg/dns/dnssec_keyscan.go
@@ -14,7 +14,7 @@ import (
 // NewPrivateKey returns a PrivateKey by parsing the string s.
 // s should be in the same form of the BIND private key files.
 func (k *DNSKEY) NewPrivateKey(s string) (crypto.PrivateKey, error) {
-	if s[len(s)-1] != '\n' { // We need a closing newline
+	if s == "" || s[len(s)-1] != '\n' { // We need a closing newline
 		return k.ReadPrivateKey(strings.NewReader(s+"\n"), "")
 	}
 	return k.ReadPrivateKey(strings.NewReader(s), "")

--- a/vendor/github.com/miekg/dns/doc.go
+++ b/vendor/github.com/miekg/dns/doc.go
@@ -203,7 +203,7 @@ RFC 6895 sets aside a range of type codes for private use. This range
 is 65,280 - 65,534 (0xFF00 - 0xFFFE). When experimenting with new Resource Records these
 can be used, before requesting an official type code from IANA.
 
-see http://miek.nl/posts/2014/Sep/21/Private%20RRs%20and%20IDN%20in%20Go%20DNS/ for more
+see http://miek.nl/2014/September/21/idn-and-private-rr-in-go-dns/ for more
 information.
 
 EDNS0

--- a/vendor/github.com/miekg/dns/edns.go
+++ b/vendor/github.com/miekg/dns/edns.go
@@ -4,25 +4,27 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 )
 
 // EDNS0 Option codes.
 const (
-	EDNS0LLQ         = 0x1     // long lived queries: http://tools.ietf.org/html/draft-sekar-dns-llq-01
-	EDNS0UL          = 0x2     // update lease draft: http://files.dns-sd.org/draft-sekar-dns-ul.txt
-	EDNS0NSID        = 0x3     // nsid (RFC5001)
-	EDNS0DAU         = 0x5     // DNSSEC Algorithm Understood
-	EDNS0DHU         = 0x6     // DS Hash Understood
-	EDNS0N3U         = 0x7     // NSEC3 Hash Understood
-	EDNS0SUBNET      = 0x8     // client-subnet (RFC6891)
-	EDNS0EXPIRE      = 0x9     // EDNS0 expire
-	EDNS0COOKIE      = 0xa     // EDNS0 Cookie
-	EDNS0SUBNETDRAFT = 0x50fa  // Don't use! Use EDNS0SUBNET
-	EDNS0LOCALSTART  = 0xFDE9  // Beginning of range reserved for local/experimental use (RFC6891)
-	EDNS0LOCALEND    = 0xFFFE  // End of range reserved for local/experimental use (RFC6891)
-	_DO              = 1 << 15 // dnssec ok
+	EDNS0LLQ          = 0x1     // long lived queries: http://tools.ietf.org/html/draft-sekar-dns-llq-01
+	EDNS0UL           = 0x2     // update lease draft: http://files.dns-sd.org/draft-sekar-dns-ul.txt
+	EDNS0NSID         = 0x3     // nsid (RFC5001)
+	EDNS0DAU          = 0x5     // DNSSEC Algorithm Understood
+	EDNS0DHU          = 0x6     // DS Hash Understood
+	EDNS0N3U          = 0x7     // NSEC3 Hash Understood
+	EDNS0SUBNET       = 0x8     // client-subnet (RFC6891)
+	EDNS0EXPIRE       = 0x9     // EDNS0 expire
+	EDNS0COOKIE       = 0xa     // EDNS0 Cookie
+	EDNS0TCPKEEPALIVE = 0xb     // EDNS0 tcp keep alive (RFC7828)
+	EDNS0SUBNETDRAFT  = 0x50fa  // Don't use! Use EDNS0SUBNET
+	EDNS0LOCALSTART   = 0xFDE9  // Beginning of range reserved for local/experimental use (RFC6891)
+	EDNS0LOCALEND     = 0xFFFE  // End of range reserved for local/experimental use (RFC6891)
+	_DO               = 1 << 15 // dnssec ok
 )
 
 // OPT is the EDNS0 RR appended to messages to convey extra (meta) information.
@@ -128,8 +130,18 @@ func (rr *OPT) Do() bool {
 }
 
 // SetDo sets the DO (DNSSEC OK) bit.
-func (rr *OPT) SetDo() {
-	rr.Hdr.Ttl |= _DO
+// If we pass an argument, set the DO bit to that value.
+// It is possible to pass 2 or more arguments. Any arguments after the 1st is silently ignored.
+func (rr *OPT) SetDo(do ...bool) {
+	if len(do) == 1 {
+		if do[0] {
+			rr.Hdr.Ttl |= _DO
+		} else {
+			rr.Hdr.Ttl &^= _DO
+		}
+	} else {
+		rr.Hdr.Ttl |= _DO
+	}
 }
 
 // EDNS0 defines an EDNS0 Option. An OPT RR can have multiple options appended to it.
@@ -185,7 +197,7 @@ func (e *EDNS0_NSID) String() string        { return string(e.Nsid) }
 //	e := new(dns.EDNS0_SUBNET)
 //	e.Code = dns.EDNS0SUBNET
 //	e.Family = 1	// 1 for IPv4 source address, 2 for IPv6
-//	e.NetMask = 32	// 32 for IPV4, 128 for IPv6
+//	e.SourceNetMask = 32	// 32 for IPV4, 128 for IPv6
 //	e.SourceScope = 0
 //	e.Address = net.ParseIP("127.0.0.1").To4()	// for IPv4
 //	// e.Address = net.ParseIP("2001:7b8:32a::2")	// for IPV6
@@ -529,4 +541,57 @@ func (e *EDNS0_LOCAL) unpack(b []byte) error {
 		return ErrBuf
 	}
 	return nil
+}
+
+type EDNS0_TCP_KEEPALIVE struct {
+	Code    uint16 // Always EDNSTCPKEEPALIVE
+	Length  uint16 // the value 0 if the TIMEOUT is omitted, the value 2 if it is present;
+	Timeout uint16 // an idle timeout value for the TCP connection, specified in units of 100 milliseconds, encoded in network byte order.
+}
+
+func (e *EDNS0_TCP_KEEPALIVE) Option() uint16 {
+	return EDNS0TCPKEEPALIVE
+}
+
+func (e *EDNS0_TCP_KEEPALIVE) pack() ([]byte, error) {
+	if e.Timeout != 0 && e.Length != 2 {
+		return nil, errors.New("dns: timeout specified but length is not 2")
+	}
+	if e.Timeout == 0 && e.Length != 0 {
+		return nil, errors.New("dns: timeout not specified but length is not 0")
+	}
+	b := make([]byte, 4+e.Length)
+	binary.BigEndian.PutUint16(b[0:], e.Code)
+	binary.BigEndian.PutUint16(b[2:], e.Length)
+	if e.Length == 2 {
+		binary.BigEndian.PutUint16(b[4:], e.Timeout)
+	}
+	return b, nil
+}
+
+func (e *EDNS0_TCP_KEEPALIVE) unpack(b []byte) error {
+	if len(b) < 4 {
+		return ErrBuf
+	}
+	e.Length = binary.BigEndian.Uint16(b[2:4])
+	if e.Length != 0 && e.Length != 2 {
+		return errors.New("dns: length mismatch, want 0/2 but got " + strconv.FormatUint(uint64(e.Length), 10))
+	}
+	if e.Length == 2 {
+		if len(b) < 6 {
+			return ErrBuf
+		}
+		e.Timeout = binary.BigEndian.Uint16(b[4:6])
+	}
+	return nil
+}
+
+func (e *EDNS0_TCP_KEEPALIVE) String() (s string) {
+	s = "use tcp keep-alive"
+	if e.Length == 0 {
+		s += ", timeout omitted"
+	} else {
+		s += fmt.Sprintf(", timeout %dms", e.Timeout*100)
+	}
+	return
 }

--- a/vendor/github.com/miekg/dns/msg.go
+++ b/vendor/github.com/miekg/dns/msg.go
@@ -58,7 +58,7 @@ var (
 	ErrTruncated     error = &Error{err: "failed to unpack truncated message"} // ErrTruncated indicates that we failed to unpack a truncated message. We unpacked as much as we had so Msg can still be used, if desired.
 )
 
-// Id, by default, returns a 16 bits random number to be used as a
+// Id by default, returns a 16 bits random number to be used as a
 // message id. The random provided should be good enough. This being a
 // variable the function can be reassigned to a custom function.
 // For instance, to make it return a static value:
@@ -203,12 +203,6 @@ func packDomainName(s string, msg []byte, off int, compression map[string]int, c
 					bs[j] = bs[j+2]
 				}
 				ls -= 2
-			} else if bs[i] == 't' {
-				bs[i] = '\t'
-			} else if bs[i] == 'r' {
-				bs[i] = '\r'
-			} else if bs[i] == 'n' {
-				bs[i] = '\n'
 			}
 			escapedDot = bs[i] == '.'
 			bsFresh = false
@@ -335,10 +329,6 @@ Loop:
 					fallthrough
 				case '"', '\\':
 					s = append(s, '\\', b)
-				case '\t':
-					s = append(s, '\\', 't')
-				case '\r':
-					s = append(s, '\\', 'r')
 				default:
 					if b < 32 || b >= 127 { // unprintable use \DDD
 						var buf [3]byte
@@ -431,12 +421,6 @@ func packTxtString(s string, msg []byte, offset int, tmp []byte) (int, error) {
 			if i+2 < len(bs) && isDigit(bs[i]) && isDigit(bs[i+1]) && isDigit(bs[i+2]) {
 				msg[offset] = dddToByte(bs[i:])
 				i += 2
-			} else if bs[i] == 't' {
-				msg[offset] = '\t'
-			} else if bs[i] == 'r' {
-				msg[offset] = '\r'
-			} else if bs[i] == 'n' {
-				msg[offset] = '\n'
 			} else {
 				msg[offset] = bs[i]
 			}
@@ -508,12 +492,6 @@ func unpackTxtString(msg []byte, offset int) (string, int, error) {
 		switch b {
 		case '"', '\\':
 			s = append(s, '\\', b)
-		case '\t':
-			s = append(s, `\t`...)
-		case '\r':
-			s = append(s, `\r`...)
-		case '\n':
-			s = append(s, `\n`...)
 		default:
 			if b < 32 || b > 127 { // unprintable
 				var buf [3]byte
@@ -781,9 +759,6 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	if dh, off, err = unpackMsgHdr(msg, off); err != nil {
 		return err
 	}
-	if off == len(msg) {
-		return ErrTruncated
-	}
 
 	dns.Id = dh.Id
 	dns.Response = (dh.Bits & _QR) != 0
@@ -796,6 +771,10 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	dns.AuthenticatedData = (dh.Bits & _AD) != 0
 	dns.CheckingDisabled = (dh.Bits & _CD) != 0
 	dns.Rcode = int(dh.Bits & 0xF)
+
+	if off == len(msg) {
+		return ErrTruncated
+	}
 
 	// Optimistically use the count given to us in the header
 	dns.Question = make([]Question, 0, int(dh.Qdcount))

--- a/vendor/github.com/miekg/dns/msg_generate.go
+++ b/vendor/github.com/miekg/dns/msg_generate.go
@@ -117,9 +117,9 @@ return off, err
 			switch {
 			case st.Tag(i) == `dns:"-"`: // ignored
 			case st.Tag(i) == `dns:"cdomain-name"`:
-				fallthrough
-			case st.Tag(i) == `dns:"domain-name"`:
 				o("off, err = PackDomainName(rr.%s, msg, off, compression, compress)\n")
+			case st.Tag(i) == `dns:"domain-name"`:
+				o("off, err = PackDomainName(rr.%s, msg, off, compression, false)\n")
 			case st.Tag(i) == `dns:"a"`:
 				o("off, err = packDataA(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"aaaa"`:

--- a/vendor/github.com/miekg/dns/msg_helpers.go
+++ b/vendor/github.com/miekg/dns/msg_helpers.go
@@ -263,8 +263,6 @@ func unpackString(msg []byte, off int) (string, int, error) {
 		switch b {
 		case '"', '\\':
 			s = append(s, '\\', b)
-		case '\t', '\r', '\n':
-			s = append(s, b)
 		default:
 			if b < 32 || b > 127 { // unprintable
 				var buf [3]byte

--- a/vendor/github.com/miekg/dns/scan.go
+++ b/vendor/github.com/miekg/dns/scan.go
@@ -627,6 +627,7 @@ func zlexer(s *scan, c chan lex) {
 			if stri > 0 {
 				l.value = zString
 				l.token = string(str[:stri])
+				l.tokenUpper = strings.ToUpper(l.token)
 				l.length = stri
 				debug.Printf("[4 %+v]", l.token)
 				c <- l
@@ -663,6 +664,7 @@ func zlexer(s *scan, c chan lex) {
 					owner = true
 					l.value = zNewline
 					l.token = "\n"
+					l.tokenUpper = l.token
 					l.length = 1
 					l.comment = string(com[:comi])
 					debug.Printf("[3 %+v %+v]", l.token, l.comment)
@@ -696,6 +698,7 @@ func zlexer(s *scan, c chan lex) {
 				}
 				l.value = zNewline
 				l.token = "\n"
+				l.tokenUpper = l.token
 				l.length = 1
 				debug.Printf("[1 %+v]", l.token)
 				c <- l
@@ -740,6 +743,7 @@ func zlexer(s *scan, c chan lex) {
 			if stri != 0 {
 				l.value = zString
 				l.token = string(str[:stri])
+				l.tokenUpper = strings.ToUpper(l.token)
 				l.length = stri
 
 				debug.Printf("[%+v]", l.token)
@@ -750,6 +754,7 @@ func zlexer(s *scan, c chan lex) {
 			// send quote itself as separate token
 			l.value = zQuote
 			l.token = "\""
+			l.tokenUpper = l.token
 			l.length = 1
 			c <- l
 			quote = !quote
@@ -775,6 +780,7 @@ func zlexer(s *scan, c chan lex) {
 				brace--
 				if brace < 0 {
 					l.token = "extra closing brace"
+					l.tokenUpper = l.token
 					l.err = true
 					debug.Printf("[%+v]", l.token)
 					c <- l
@@ -799,6 +805,7 @@ func zlexer(s *scan, c chan lex) {
 	if stri > 0 {
 		// Send remainder
 		l.token = string(str[:stri])
+		l.tokenUpper = strings.ToUpper(l.token)
 		l.length = stri
 		l.value = zString
 		debug.Printf("[%+v]", l.token)

--- a/vendor/github.com/miekg/dns/scan_rr.go
+++ b/vendor/github.com/miekg/dns/scan_rr.go
@@ -64,74 +64,63 @@ func endingToString(c chan lex, errstr, f string) (string, *ParseError, string) 
 	return s, nil, l.comment
 }
 
-// A remainder of the rdata with embedded spaces, return the parsed string slice (sans the spaces)
-// or an error
+// A remainder of the rdata with embedded spaces, split on unquoted whitespace
+// and return the parsed string slice or an error
 func endingToTxtSlice(c chan lex, errstr, f string) ([]string, *ParseError, string) {
 	// Get the remaining data until we see a zNewline
-	quote := false
 	l := <-c
-	var s []string
 	if l.err {
-		return s, &ParseError{f, errstr, l}, ""
+		return nil, &ParseError{f, errstr, l}, ""
 	}
-	switch l.value == zQuote {
-	case true: // A number of quoted string
-		s = make([]string, 0)
-		empty := true
-		for l.value != zNewline && l.value != zEOF {
-			if l.err {
-				return nil, &ParseError{f, errstr, l}, ""
-			}
-			switch l.value {
-			case zString:
-				empty = false
-				if len(l.token) > 255 {
-					// split up tokens that are larger than 255 into 255-chunks
-					sx := []string{}
-					p, i := 0, 255
-					for {
-						if i <= len(l.token) {
-							sx = append(sx, l.token[p:i])
-						} else {
-							sx = append(sx, l.token[p:])
-							break
 
-						}
-						p, i = p+255, i+255
-					}
-					s = append(s, sx...)
-					break
-				}
-
-				s = append(s, l.token)
-			case zBlank:
-				if quote {
-					// zBlank can only be seen in between txt parts.
-					return nil, &ParseError{f, errstr, l}, ""
-				}
-			case zQuote:
-				if empty && quote {
-					s = append(s, "")
-				}
-				quote = !quote
-				empty = true
-			default:
-				return nil, &ParseError{f, errstr, l}, ""
-			}
-			l = <-c
-		}
-		if quote {
+	// Build the slice
+	s := make([]string, 0)
+	quote := false
+	empty := false
+	for l.value != zNewline && l.value != zEOF {
+		if l.err {
 			return nil, &ParseError{f, errstr, l}, ""
 		}
-	case false: // Unquoted text record
-		s = make([]string, 1)
-		for l.value != zNewline && l.value != zEOF {
-			if l.err {
-				return s, &ParseError{f, errstr, l}, ""
+		switch l.value {
+		case zString:
+			empty = false
+			if len(l.token) > 255 {
+				// split up tokens that are larger than 255 into 255-chunks
+				sx := []string{}
+				p, i := 0, 255
+				for {
+					if i <= len(l.token) {
+						sx = append(sx, l.token[p:i])
+					} else {
+						sx = append(sx, l.token[p:])
+						break
+
+					}
+					p, i = p+255, i+255
+				}
+				s = append(s, sx...)
+				break
 			}
-			s[0] += l.token
-			l = <-c
+
+			s = append(s, l.token)
+		case zBlank:
+			if quote {
+				// zBlank can only be seen in between txt parts.
+				return nil, &ParseError{f, errstr, l}, ""
+			}
+		case zQuote:
+			if empty && quote {
+				s = append(s, "")
+			}
+			quote = !quote
+			empty = true
+		default:
+			return nil, &ParseError{f, errstr, l}, ""
 		}
+		l = <-c
+	}
+	if quote {
+		return nil, &ParseError{f, errstr, l}, ""
 	}
 	return s, nil, l.comment
 }
@@ -1746,6 +1735,41 @@ func setTLSA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	return rr, nil, c1
 }
 
+func setSMIMEA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
+	rr := new(SMIMEA)
+	rr.Hdr = h
+	l := <-c
+	if l.length == 0 {
+		return rr, nil, l.comment
+	}
+	i, e := strconv.Atoi(l.token)
+	if e != nil || l.err {
+		return nil, &ParseError{f, "bad SMIMEA Usage", l}, ""
+	}
+	rr.Usage = uint8(i)
+	<-c // zBlank
+	l = <-c
+	i, e = strconv.Atoi(l.token)
+	if e != nil || l.err {
+		return nil, &ParseError{f, "bad SMIMEA Selector", l}, ""
+	}
+	rr.Selector = uint8(i)
+	<-c // zBlank
+	l = <-c
+	i, e = strconv.Atoi(l.token)
+	if e != nil || l.err {
+		return nil, &ParseError{f, "bad SMIMEA MatchingType", l}, ""
+	}
+	rr.MatchingType = uint8(i)
+	// So this needs be e2 (i.e. different than e), because...??t
+	s, e2, c1 := endingToString(c, "bad SMIMEA Certificate", f)
+	if e2 != nil {
+		return nil, e2, c1
+	}
+	rr.Certificate = s
+	return rr, nil, c1
+}
+
 func setRFC3597(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(RFC3597)
 	rr.Hdr = h
@@ -1992,9 +2016,12 @@ func setUINFO(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 	s, e, c1 := endingToTxtSlice(c, "bad UINFO Uinfo", f)
 	if e != nil {
-		return nil, e, ""
+		return nil, e, c1
 	}
-	rr.Uinfo = s[0] // silently discard anything above
+	if ln := len(s); ln == 0 {
+		return rr, nil, c1
+	}
+	rr.Uinfo = s[0] // silently discard anything after the first character-string
 	return rr, nil, c1
 }
 
@@ -2128,6 +2155,7 @@ var typeToparserFunc = map[uint16]parserFunc{
 	TypeRP:         {setRP, false},
 	TypeRRSIG:      {setRRSIG, true},
 	TypeRT:         {setRT, false},
+	TypeSMIMEA:     {setSMIMEA, true},
 	TypeSOA:        {setSOA, false},
 	TypeSPF:        {setSPF, true},
 	TypeSRV:        {setSRV, false},

--- a/vendor/github.com/miekg/dns/server.go
+++ b/vendor/github.com/miekg/dns/server.go
@@ -147,7 +147,7 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 				b[i] |= ('a' - 'A')
 			}
 		}
-		if h, ok := mux.z[string(b[:l])]; ok { // 'causes garbage, might want to change the map key
+		if h, ok := mux.z[string(b[:l])]; ok { // causes garbage, might want to change the map key
 			if t != TypeDS {
 				return h
 			}
@@ -339,7 +339,7 @@ func (srv *Server) ListenAndServe() error {
 		network := "tcp"
 		if srv.Net == "tcp4-tls" {
 			network = "tcp4"
-		} else if srv.Net == "tcp6" {
+		} else if srv.Net == "tcp6-tls" {
 			network = "tcp6"
 		}
 
@@ -389,7 +389,9 @@ func (srv *Server) ActivateAndServe() error {
 		if srv.UDPSize == 0 {
 			srv.UDPSize = MinMsgSize
 		}
-		if t, ok := pConn.(*net.UDPConn); ok {
+		// Check PacketConn interface's type is valid and value
+		// is not nil
+		if t, ok := pConn.(*net.UDPConn); ok && t != nil {
 			if e := setUDPSocketOptions(t); e != nil {
 				return e
 			}

--- a/vendor/github.com/miekg/dns/smimea.go
+++ b/vendor/github.com/miekg/dns/smimea.go
@@ -1,0 +1,47 @@
+package dns
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+)
+
+// Sign creates a SMIMEA record from an SSL certificate.
+func (r *SMIMEA) Sign(usage, selector, matchingType int, cert *x509.Certificate) (err error) {
+	r.Hdr.Rrtype = TypeSMIMEA
+	r.Usage = uint8(usage)
+	r.Selector = uint8(selector)
+	r.MatchingType = uint8(matchingType)
+
+	r.Certificate, err = CertificateToDANE(r.Selector, r.MatchingType, cert)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Verify verifies a SMIMEA record against an SSL certificate. If it is OK
+// a nil error is returned.
+func (r *SMIMEA) Verify(cert *x509.Certificate) error {
+	c, err := CertificateToDANE(r.Selector, r.MatchingType, cert)
+	if err != nil {
+		return err // Not also ErrSig?
+	}
+	if r.Certificate == c {
+		return nil
+	}
+	return ErrSig // ErrSig, really?
+}
+
+// SIMEAName returns the ownername of a SMIMEA resource record as per the
+// format specified in RFC 'draft-ietf-dane-smime-12' Section 2 and 3
+func SMIMEAName(email_address string, domain_name string) (string, error) {
+	hasher := sha256.New()
+	hasher.Write([]byte(email_address))
+
+	// RFC Section 3: "The local-part is hashed using the SHA2-256
+	// algorithm with the hash truncated to 28 octets and
+	// represented in its hexadecimal representation to become the
+	// left-most label in the prepared domain name"
+	return hex.EncodeToString(hasher.Sum(nil)[:28]) + "." + "_smimecert." + domain_name, nil
+}

--- a/vendor/github.com/miekg/dns/tlsa.go
+++ b/vendor/github.com/miekg/dns/tlsa.go
@@ -1,49 +1,10 @@
 package dns
 
 import (
-	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/x509"
-	"encoding/hex"
-	"errors"
-	"io"
 	"net"
 	"strconv"
 )
-
-// CertificateToDANE converts a certificate to a hex string as used in the TLSA record.
-func CertificateToDANE(selector, matchingType uint8, cert *x509.Certificate) (string, error) {
-	switch matchingType {
-	case 0:
-		switch selector {
-		case 0:
-			return hex.EncodeToString(cert.Raw), nil
-		case 1:
-			return hex.EncodeToString(cert.RawSubjectPublicKeyInfo), nil
-		}
-	case 1:
-		h := sha256.New()
-		switch selector {
-		case 0:
-			io.WriteString(h, string(cert.Raw))
-			return hex.EncodeToString(h.Sum(nil)), nil
-		case 1:
-			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
-			return hex.EncodeToString(h.Sum(nil)), nil
-		}
-	case 2:
-		h := sha512.New()
-		switch selector {
-		case 0:
-			io.WriteString(h, string(cert.Raw))
-			return hex.EncodeToString(h.Sum(nil)), nil
-		case 1:
-			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
-			return hex.EncodeToString(h.Sum(nil)), nil
-		}
-	}
-	return "", errors.New("dns: bad TLSA MatchingType or TLSA Selector")
-}
 
 // Sign creates a TLSA record from an SSL certificate.
 func (r *TLSA) Sign(usage, selector, matchingType int, cert *x509.Certificate) (err error) {

--- a/vendor/github.com/miekg/dns/types.go
+++ b/vendor/github.com/miekg/dns/types.go
@@ -70,6 +70,7 @@ const (
 	TypeNSEC3      uint16 = 50
 	TypeNSEC3PARAM uint16 = 51
 	TypeTLSA       uint16 = 52
+	TypeSMIMEA     uint16 = 53
 	TypeHIP        uint16 = 55
 	TypeNINFO      uint16 = 56
 	TypeRKEY       uint16 = 57
@@ -479,12 +480,6 @@ func appendDomainNameByte(s []byte, b byte) []byte {
 
 func appendTXTStringByte(s []byte, b byte) []byte {
 	switch b {
-	case '\t':
-		return append(s, '\\', 't')
-	case '\r':
-		return append(s, '\\', 'r')
-	case '\n':
-		return append(s, '\\', 'n')
 	case '"', '\\':
 		return append(s, '\\', b)
 	}
@@ -524,17 +519,8 @@ func nextByte(b []byte, offset int) (byte, int) {
 			return dddToByte(b[offset+1:]), 4
 		}
 	}
-	// not \ddd, maybe a control char
-	switch b[offset+1] {
-	case 't':
-		return '\t', 2
-	case 'r':
-		return '\r', 2
-	case 'n':
-		return '\n', 2
-	default:
-		return b[offset+1], 2
-	}
+	// not \ddd, just an RFC 1035 "quoted" character
+	return b[offset+1], 2
 }
 
 type SPF struct {
@@ -1047,6 +1033,28 @@ func (rr *TLSA) String() string {
 		" " + rr.Certificate
 }
 
+type SMIMEA struct {
+	Hdr          RR_Header
+	Usage        uint8
+	Selector     uint8
+	MatchingType uint8
+	Certificate  string `dns:"hex"`
+}
+
+func (rr *SMIMEA) String() string {
+	s := rr.Hdr.String() +
+		strconv.Itoa(int(rr.Usage)) +
+		" " + strconv.Itoa(int(rr.Selector)) +
+		" " + strconv.Itoa(int(rr.MatchingType))
+
+	// Every Nth char needs a space on this output. If we output
+	// this as one giant line, we can't read it can in because in some cases
+	// the cert length overflows scan.maxTok (2048).
+	sx := splitN(rr.Certificate, 1024) // conservative value here
+	s += " " + strings.Join(sx, " ")
+	return s
+}
+
 type HIP struct {
 	Hdr                RR_Header
 	HitLength          uint8
@@ -1246,4 +1254,26 @@ func copyIP(ip net.IP) net.IP {
 	p := make(net.IP, len(ip))
 	copy(p, ip)
 	return p
+}
+
+// SplitN splits a string into N sized string chunks.
+// This might become an exported function once.
+func splitN(s string, n int) []string {
+	if len(s) < n {
+		return []string{s}
+	}
+	sx := []string{}
+	p, i := 0, n
+	for {
+		if i <= len(s) {
+			sx = append(sx, s[p:i])
+		} else {
+			sx = append(sx, s[p:])
+			break
+
+		}
+		p, i = p+n, i+n
+	}
+
+	return sx
 }

--- a/vendor/github.com/miekg/dns/udp_linux.go
+++ b/vendor/github.com/miekg/dns/udp_linux.go
@@ -22,14 +22,17 @@ func setUDPSocketOptions4(conn *net.UDPConn) error {
 		return err
 	}
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1); err != nil {
+		file.Close()
 		return err
 	}
 	// Calling File() above results in the connection becoming blocking, we must fix that.
 	// See https://github.com/miekg/dns/issues/279
 	err = syscall.SetNonblock(int(file.Fd()), true)
 	if err != nil {
+		file.Close()
 		return err
 	}
+	file.Close()
 	return nil
 }
 
@@ -40,12 +43,15 @@ func setUDPSocketOptions6(conn *net.UDPConn) error {
 		return err
 	}
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_RECVPKTINFO, 1); err != nil {
+		file.Close()
 		return err
 	}
 	err = syscall.SetNonblock(int(file.Fd()), true)
 	if err != nil {
+		file.Close()
 		return err
 	}
+	file.Close()
 	return nil
 }
 
@@ -59,8 +65,10 @@ func getUDPSocketOptions6Only(conn *net.UDPConn) (bool, error) {
 	// dual stack. See http://stackoverflow.com/questions/1618240/how-to-support-both-ipv4-and-ipv6-connections
 	v6only, err := syscall.GetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY)
 	if err != nil {
+		file.Close()
 		return false, err
 	}
+	file.Close()
 	return v6only == 1, nil
 }
 
@@ -69,5 +77,6 @@ func getUDPSocketName(conn *net.UDPConn) (syscall.Sockaddr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	return syscall.Getsockname(int(file.Fd()))
 }

--- a/vendor/github.com/miekg/dns/zmsg.go
+++ b/vendor/github.com/miekg/dns/zmsg.go
@@ -221,7 +221,7 @@ func (rr *DNAME) pack(msg []byte, off int, compression map[string]int, compress 
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Target, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -447,7 +447,7 @@ func (rr *KX) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Exchanger, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Exchanger, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -539,7 +539,7 @@ func (rr *LP) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Fqdn, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Fqdn, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -679,7 +679,7 @@ func (rr *NAPTR) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Replacement, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Replacement, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -753,7 +753,7 @@ func (rr *NSAPPTR) pack(msg []byte, off int, compression map[string]int, compres
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Ptr, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Ptr, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -767,7 +767,7 @@ func (rr *NSEC) pack(msg []byte, off int, compression map[string]int, compress b
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.NextDomain, msg, off, compression, compress)
+	off, err = PackDomainName(rr.NextDomain, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -905,11 +905,11 @@ func (rr *PX) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Map822, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Map822, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Mapx400, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Mapx400, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -963,11 +963,11 @@ func (rr *RP) pack(msg []byte, off int, compression map[string]int, compress boo
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mbox, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Mbox, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Txt, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Txt, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1009,7 +1009,7 @@ func (rr *RRSIG) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.SignerName, msg, off, compression, compress)
+	off, err = PackDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1073,11 +1073,37 @@ func (rr *SIG) pack(msg []byte, off int, compression map[string]int, compress bo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.SignerName, msg, off, compression, compress)
+	off, err = PackDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
 	off, err = packStringBase64(rr.Signature, msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.Header().Rdlength = uint16(off - headerEnd)
+	return off, nil
+}
+
+func (rr *SMIMEA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+	off, err := rr.Hdr.pack(msg, off, compression, compress)
+	if err != nil {
+		return off, err
+	}
+	headerEnd := off
+	off, err = packUint8(rr.Usage, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packUint8(rr.Selector, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packUint8(rr.MatchingType, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packStringHex(rr.Certificate, msg, off)
 	if err != nil {
 		return off, err
 	}
@@ -1155,7 +1181,7 @@ func (rr *SRV) pack(msg []byte, off int, compression map[string]int, compress bo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Target, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1217,11 +1243,11 @@ func (rr *TALINK) pack(msg []byte, off int, compression map[string]int, compress
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.PreviousName, msg, off, compression, compress)
+	off, err = PackDomainName(rr.PreviousName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.NextName, msg, off, compression, compress)
+	off, err = PackDomainName(rr.NextName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1235,7 +1261,7 @@ func (rr *TKEY) pack(msg []byte, off int, compression map[string]int, compress b
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Algorithm, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1307,7 +1333,7 @@ func (rr *TSIG) pack(msg []byte, off int, compression map[string]int, compress b
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Algorithm, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -2907,6 +2933,44 @@ func unpackSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
 	return rr, off, err
 }
 
+func unpackSMIMEA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SMIMEA)
+	rr.Hdr = h
+	if noRdata(h) {
+		return rr, off, nil
+	}
+	var err error
+	rdStart := off
+	_ = rdStart
+
+	rr.Usage, off, err = unpackUint8(msg, off)
+	if err != nil {
+		return rr, off, err
+	}
+	if off == len(msg) {
+		return rr, off, nil
+	}
+	rr.Selector, off, err = unpackUint8(msg, off)
+	if err != nil {
+		return rr, off, err
+	}
+	if off == len(msg) {
+		return rr, off, nil
+	}
+	rr.MatchingType, off, err = unpackUint8(msg, off)
+	if err != nil {
+		return rr, off, err
+	}
+	if off == len(msg) {
+		return rr, off, nil
+	}
+	rr.Certificate, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
+	if err != nil {
+		return rr, off, err
+	}
+	return rr, off, err
+}
+
 func unpackSOA(h RR_Header, msg []byte, off int) (RR, int, error) {
 	rr := new(SOA)
 	rr.Hdr = h
@@ -3447,6 +3511,7 @@ var typeToUnpack = map[uint16]func(RR_Header, []byte, int) (RR, int, error){
 	TypeRRSIG:      unpackRRSIG,
 	TypeRT:         unpackRT,
 	TypeSIG:        unpackSIG,
+	TypeSMIMEA:     unpackSMIMEA,
 	TypeSOA:        unpackSOA,
 	TypeSPF:        unpackSPF,
 	TypeSRV:        unpackSRV,

--- a/vendor/github.com/miekg/dns/ztypes.go
+++ b/vendor/github.com/miekg/dns/ztypes.go
@@ -62,6 +62,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeRRSIG:      func() RR { return new(RRSIG) },
 	TypeRT:         func() RR { return new(RT) },
 	TypeSIG:        func() RR { return new(SIG) },
+	TypeSMIMEA:     func() RR { return new(SMIMEA) },
 	TypeSOA:        func() RR { return new(SOA) },
 	TypeSPF:        func() RR { return new(SPF) },
 	TypeSRV:        func() RR { return new(SRV) },
@@ -141,6 +142,7 @@ var TypeToString = map[uint16]string{
 	TypeRT:         "RT",
 	TypeReserved:   "Reserved",
 	TypeSIG:        "SIG",
+	TypeSMIMEA:     "SMIMEA",
 	TypeSOA:        "SOA",
 	TypeSPF:        "SPF",
 	TypeSRV:        "SRV",
@@ -213,6 +215,7 @@ func (rr *RP) Header() *RR_Header         { return &rr.Hdr }
 func (rr *RRSIG) Header() *RR_Header      { return &rr.Hdr }
 func (rr *RT) Header() *RR_Header         { return &rr.Hdr }
 func (rr *SIG) Header() *RR_Header        { return &rr.Hdr }
+func (rr *SMIMEA) Header() *RR_Header     { return &rr.Hdr }
 func (rr *SOA) Header() *RR_Header        { return &rr.Hdr }
 func (rr *SPF) Header() *RR_Header        { return &rr.Hdr }
 func (rr *SRV) Header() *RR_Header        { return &rr.Hdr }
@@ -514,6 +517,14 @@ func (rr *RT) len() int {
 	l += len(rr.Host) + 1
 	return l
 }
+func (rr *SMIMEA) len() int {
+	l := rr.Hdr.len()
+	l += 1 // Usage
+	l += 1 // Selector
+	l += 1 // MatchingType
+	l += len(rr.Certificate)/2 + 1
+	return l
+}
 func (rr *SOA) len() int {
 	l := rr.Hdr.len()
 	l += len(rr.Ns) + 1
@@ -779,6 +790,9 @@ func (rr *RRSIG) copy() RR {
 }
 func (rr *RT) copy() RR {
 	return &RT{*rr.Hdr.copyHeader(), rr.Preference, rr.Host}
+}
+func (rr *SMIMEA) copy() RR {
+	return &SMIMEA{*rr.Hdr.copyHeader(), rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
 }
 func (rr *SOA) copy() RR {
 	return &SOA{*rr.Hdr.copyHeader(), rr.Ns, rr.Mbox, rr.Serial, rr.Refresh, rr.Retry, rr.Expire, rr.Minttl}


### PR DESCRIPTION
Bumped to the following commit to fix non-compliant compression of various fields. 

commit 99f84ae56e75126dd77e5de4fae2ea034a468ca1
Author: Matthijs Mekking <github@pletterpet.nl>
Date:   Mon Jan 30 11:53:01 2017 +0100

    return errTruncated after setting header bits (#442)

