### PR TITLE
resolver: make resolver_test.go pass golint

### DIFF
--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -230,7 +230,7 @@ func runHandlers() error {
 		var rw ResponseRecorder
 		tt.HandlerFunc(&rw, tt.Msg)
 		if got, want := rw.Msg, tt.Msg; !(Msg{got}).equivalent(Msg{want}) {
-			return fmt.Errorf("Test #%d\n%v\n%s\n", i, pretty.Sprint(tt.Msg.Question), pretty.Compare(got, want))
+			return fmt.Errorf("test #%d\n%v\n%s", i, pretty.Sprint(tt.Msg.Question), pretty.Compare(got, want))
 		}
 	}
 	return nil


### PR DESCRIPTION
CI is complaining of `resolver/resolver_test.go` not passing golint
https://jenkins.mesosphere.com/service/jenkins/job/public-mesos-dns-pulls/173/console

This PR fixes the linting issue.