### PR TITLE
WIP: numbered ports

### DIFF
--- a/docs/docs/configuration-parameters.md
+++ b/docs/docs/configuration-parameters.md
@@ -4,7 +4,7 @@ title: Mesos-DNS Configuration Parameters
 
 ##  Mesos-DNS Configuration Parameters
 
-Mesos-DNS is configured through the parameters in a json file. You can point Mesos-DNS to a specific configuration file using the argument `-config=pathto/file.json`. If no configuration file is passed as an argument, Mesos-DNS will look for file `config.json` in the current directory. 
+Mesos-DNS is configured through the parameters in a json file. You can point Mesos-DNS to a specific configuration file using the argument `-config=pathto/file.json`. If no configuration file is passed as an argument, Mesos-DNS will look for file `config.json` in the current directory.
 
 The configuration file should include the following fields:
 
@@ -25,7 +25,7 @@ The configuration file should include the following fields:
   "zoneResolvers": {
     "weave": ["172.17.0.1"]
   },
-  "timeout": 5, 
+  "timeout": 5,
   "httpon": true,
   "dnson": true,
   "httpport": 8123,
@@ -37,11 +37,12 @@ The configuration file should include the following fields:
   "SOARetry":   600,
   "SOAExpire":  86400,
   "SOAMinttl": 60,
-  "IPSources": ["netinfo", "mesos", "host"]
+  "IPSources": ["netinfo", "mesos", "host"],
+  "NumberPorts": false
 }
 ```
 
-`zk` is a link to the Zookeeper instances on the Mesos cluster. Its format is `zk://host1:port1,host2:port2/mesos/`, where the number of hosts can be one or more. The default port for Zookeeper is `2181`. Mesos-DNS will monitor the Zookeeper instances to detect the current leading master. 
+`zk` is a link to the Zookeeper instances on the Mesos cluster. Its format is `zk://host1:port1,host2:port2/mesos/`, where the number of hosts can be one or more. The default port for Zookeeper is `2181`. Mesos-DNS will monitor the Zookeeper instances to detect the current leading master.
 
 `zkDetectionTimeout` defines how long to wait (in seconds) for Zookeeper to report a new leading Mesos master.
 This timeout is activated on:
@@ -55,39 +56,39 @@ a new leading Mesos master is reported by the ZK-based master detector, the prog
 
 Defaults to `30` seconds.
 
-`masters` is a comma separated list with the IP address and port number for the master(s) in the Mesos cluster. Mesos-DNS will automatically find the leading master at any point in order to retrieve state about running tasks. If there is no leading master or the leading master is not responsive, Mesos-DNS will continue serving DNS requests based on stale information about running tasks. The `masters` field is required. 
+`masters` is a comma separated list with the IP address and port number for the master(s) in the Mesos cluster. Mesos-DNS will automatically find the leading master at any point in order to retrieve state about running tasks. If there is no leading master or the leading master is not responsive, Mesos-DNS will continue serving DNS requests based on stale information about running tasks. The `masters` field is required.
 
-It is sufficient to specify just one of the `zk` or `masters` field. If both are defined, Mesos-DNS will first attempt to detect the leading master through Zookeeper. If Zookeeper is not responding, it will fall back to using the `masters` field. Both `zk` and `master` fields are static. To update them you need to restart Mesos-DNS. We recommend you use the `zk` field since this allows the dynamic addition to Mesos masters. 
+It is sufficient to specify just one of the `zk` or `masters` field. If both are defined, Mesos-DNS will first attempt to detect the leading master through Zookeeper. If Zookeeper is not responding, it will fall back to using the `masters` field. Both `zk` and `master` fields are static. To update them you need to restart Mesos-DNS. We recommend you use the `zk` field since this allows the dynamic addition to Mesos masters.
 
 `mesosAuthentication` configures the authentication mechanism for talking to the Mesos cluster. Valid values are '', 'basic' (see `mesosCredentials`), and 'iam'. Default is ''.
 
 `mesosCredentials` is a dictionary containing a `principal` and a `secret`, corresponding to a configured authentication principal for the Mesos masters. Starting with Mesos `1.0.0`, if the masters have `http_authentication` enabled, then Mesos-DNS must authenticate. You must specify `mesosAuthentication`: `basic` to use this configuration.
 
-`refreshSeconds` is the frequency at which Mesos-DNS updates DNS records based on information retrieved from the Mesos master. The default value is 60 seconds. 
+`refreshSeconds` is the frequency at which Mesos-DNS updates DNS records based on information retrieved from the Mesos master. The default value is 60 seconds.
 
 `stateTimeoutSeconds` is the time that Mesos-DNS will wait for the Mesos master to respond to its request for state.json in seconds. The default value is 300 seconds.
 
-`ttl` is the [time to live](http://en.wikipedia.org/wiki/Time_to_live#DNS_records) value for DNS records served by Mesos-DNS, in seconds. It allows caching of the DNS record for a period of time in order to reduce DNS request rate. `ttl` should be equal or larger than `refreshSeconds`. The default value is 60 seconds. 
+`ttl` is the [time to live](http://en.wikipedia.org/wiki/Time_to_live#DNS_records) value for DNS records served by Mesos-DNS, in seconds. It allows caching of the DNS record for a period of time in order to reduce DNS request rate. `ttl` should be equal or larger than `refreshSeconds`. The default value is 60 seconds.
 
 `domain` is the domain name for the Mesos cluster. The domain name can use characters [a-z, A-Z, 0-9], `-` if it is not the first or last character of a domain portion, and `.` as a separator of the textual portions of the domain name. We recommend you avoid valid [top-level domain names](http://en.wikipedia.org/wiki/List_of_Internet_top-level_domains). The default value is `mesos`.
 
 `port` is the port number that Mesos-DNS monitors for incoming DNS requests. Requests can be sent over TCP or UDP. We recommend you use port `53` as several applications assume that the DNS server listens to this port. The default value is `53`.
 
-`resolvers` is a comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the `domain`. We ***recommend*** that you list the nameservers specified in the `/etc/resolv.conf` on the server Mesos-DNS is running. Alternatively, you can list `8.8.8.8`, which is the [Google public DNS](https://developers.google.com/speed/public-dns/) address. The `resolvers` field is required. 
+`resolvers` is a comma separated list with the IP addresses of external DNS servers that Mesos-DNS will contact to resolve any DNS requests outside the `domain`. We ***recommend*** that you list the nameservers specified in the `/etc/resolv.conf` on the server Mesos-DNS is running. Alternatively, you can list `8.8.8.8`, which is the [Google public DNS](https://developers.google.com/speed/public-dns/) address. The `resolvers` field is required.
 
 `zoneResolvers` is a dictionary of zone-specific external DNS servers, where the key is the matching zone (sans leading / trailing .). You can use this configuration option to route a subset of DNS queries to a specific set of DNS servers. Note, general, catch-all resolvers are still specified with `resolvers`.
 
-`timeout` is the timeout threshold, in seconds, for connections and requests to external DNS requests. The default value is 5 seconds. 
+`timeout` is the timeout threshold, in seconds, for connections and requests to external DNS requests. The default value is 5 seconds.
 
-`listener` is the IP address of Mesos-DNS. In SOA replies, Mesos-DNS identifies hostname `mesos-dns.domain` as the primary nameserver for the domain. It uses this IP address in an A record for `mesos-dns.domain`. The default value is "0.0.0.0", which instructs Mesos-DNS to create an A record for every IP address associated with a network interface on the server that runs the Mesos-DNS process. 
+`listener` is the IP address of Mesos-DNS. In SOA replies, Mesos-DNS identifies hostname `mesos-dns.domain` as the primary nameserver for the domain. It uses this IP address in an A record for `mesos-dns.domain`. The default value is "0.0.0.0", which instructs Mesos-DNS to create an A record for every IP address associated with a network interface on the server that runs the Mesos-DNS process.
 
-`dnson` is a boolean field that controls whether Mesos-DNS listens for DNS requests or not. The default value is `true`. 
+`dnson` is a boolean field that controls whether Mesos-DNS listens for DNS requests or not. The default value is `true`.
 
-`httpon` is a boolean field that controls whether Mesos-DNS listens for HTTP requests or not. The default value is `true`. 
+`httpon` is a boolean field that controls whether Mesos-DNS listens for HTTP requests or not. The default value is `true`.
 
 `httpport` is the port number that Mesos-DNS monitors for incoming HTTP requests. The default value is `8123`.
 
-`externalon` is a boolean field that controls whether Mesos-DNS serves requests outside of the Mesos domain. The default value is `true`. 
+`externalon` is a boolean field that controls whether Mesos-DNS serves requests outside of the Mesos domain. The default value is `true`.
 
 `SOAMname` specifies the domain name of the name server that was the original or primary source of data for the configured domain.
 The configured name will always be converted to a FQDN by ensuring it ends with a `.`. The default value is `ns1.mesos`.
@@ -102,12 +103,16 @@ The configured name will always be converted to a FQDN by ensuring it ends with 
 
 `SOAMinttl` is the minimum TTL field in the SOA record for the Mesos domain. For details, see the [RFC-2308](https://tools.ietf.org/html/rfc2308). The default value is `60`.
 
-`recurseon` controls if the DNS replies for names in the Mesos domain will indicate that recursion is available. The default value is `true`. 
+`recurseon` controls if the DNS replies for names in the Mesos domain will indicate that recursion is available. The default value is `true`.
 
 `enforceRFC952` will enforce an older, more strict set of rules for DNS labels. For details, see the [RFC-952](https://tools.ietf.org/html/rfc952). The default value is `false`.
 
 `IPSources` defines a fallback list of IP sources for task records,
 sorted by priority. If you use **Docker**, and enable the `netinfo` IPSource, it may cause tasks to become unreachable, because after Mesos 0.25, the Docker executor publishes the container's internal IP in NetworkInfo. The default value is: `["netinfo", "mesos", "host"]`
+
+`NumberPorts` enables generating service SRV records per service port.
+SRV records look like `_port{port index}._task._protocol.framework.domain`, where `_port0` is the first port for the service and `_port{number of ports assigned to the service - 1}` is the last one.
+The default value is `false`. 
 
 - `host`: Host IP of the Mesos slave where a task is running.
 - `mesos`: Mesos containerizer IP. **DEPRECATED**

--- a/records/chains.go
+++ b/records/chains.go
@@ -1,6 +1,8 @@
 package records
 
 import (
+	"fmt"
+
 	"github.com/mesosphere/mesos-dns/records/labels"
 )
 
@@ -77,4 +79,10 @@ func withNamedPort(portName string, spec labels.Func, gen chain) chain {
 		}
 		gen(records...)
 	}
+}
+
+// withNumberedPort prepends a `_port{port index}.` to records
+func withNumberedPort(portIndex int, spec labels.Func, gen chain) chain {
+	portName := fmt.Sprintf("port%d", portIndex)
+	return withNamedPort(portName, spec, gen)
 }

--- a/records/config.go
+++ b/records/config.go
@@ -106,6 +106,8 @@ type Config struct {
 	httpConfigMap httpcli.ConfigMap
 
 	MesosAuthentication httpcli.AuthMechanism
+	// when generating SRV records for task with multiple ports - do we number them in case when they are not named ports
+	NumberPorts bool
 }
 
 // NewConfig return the default config of the resolver
@@ -137,6 +139,7 @@ func NewConfig() Config {
 		IPSources:           []string{"netinfo", "mesos", "host"},
 		EnumerationOn:       true,
 		MesosAuthentication: httpcli.AuthNone,
+		NumberPorts:         false,
 	}
 }
 

--- a/records/generator.go
+++ b/records/generator.go
@@ -588,7 +588,8 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 
 		if rg.numberPorts {
 			recordName(withProtocol(protocolNone, fname, spec,
-				withNumberedPort(index, spec, asSRV(slaveTarget))))
+				withSubdomains(subdomains,
+					withNumberedPort(index, spec, asSRV(slaveTarget)))))
 		}
 	}
 
@@ -596,11 +597,16 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 		return
 	}
 
-	for _, port := range task.DiscoveryInfo.Ports.DiscoveryPorts {
+	for index, port := range task.DiscoveryInfo.Ports.DiscoveryPorts {
 		target := canonical + tail + ":" + strconv.Itoa(port.Number)
 
 		recordName(withProtocol(port.Protocol, fname, spec,
 			withNamedPort(port.Name, spec, asSRV(target))))
+
+		if rg.numberPorts {
+			recordName(withProtocol(port.Protocol, fname, spec,
+				withNumberedPort(index, spec, asSRV(target))))
+		}
 	}
 }
 

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -322,6 +322,9 @@ func TestInsertStateNumPorts(t *testing.T) {
 		{rg.As, "leader.mesos.", []string{"144.76.157.37"}},
 		{rg.As, "slave.mesos.", []string{"1.2.3.10", "1.2.3.11", "1.2.3.12"}},
 		{rg.As, "some-box.chronoswithaspaceandmixe.mesos.", []string{"1.2.3.11"}}, // ensure we translate the framework name as well
+		{rg.SRVs, "_port0._some-box._tcp.chronoswithaspaceandmixe.mesos.", []string{
+			"some-box-h3dyr-0.chronoswithaspaceandmixe.slave.mesos.:31354",
+		}},
 		{rg.As, "marathon.mesos.", []string{"1.2.3.11"}},
 		{rg.SRVs, "_big-dog._tcp.marathon.mesos.", []string{
 			"big-dog-4dfjd-0.marathon.mesos.:80",


### PR DESCRIPTION
Hi all, 

I've decided to try DNS based service discovery recently and I had the same issues as noted in issue #61 (first part of the discussion): basically we have a lot of services that use service wide clustering and requires a dedicated tcp/udp port for it, meaning that deployed services need at last two ports assigned (e.g. first port for REST, second port for clustering). This makes current `_task._protocol.framework.domain` SRV record implementation cumbersome to use. Singularity is mesos scheduler we use and it does not have named ports support (yet?).

I've added a new configuration parameter `NumberPorts`, a quick implementation for it and documentation as well as tests. Once NumberPorts is set to true - SRV records will be created for each port per task, e.g. `_port0._task._protocol.framework.domain`  will return a list of fqdns and ports for `_task` for the very first port assigned to each task instance. `_port1` is for the second port and so on.

It's deployed on a cluster I'm trying DNS-SRV discovery and so far it looks OK but more testing/validation might be required.

P.S. the implementation considers that task information has port information in assigned port order so the actual ports (low-high) are left as is. I have only done test runs on mesos 1.0.1 and so far I did not get any issues with ports being out of order.
