### PR TITLE
Updated logging regarding new masters.

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 			} else {
 				timeout.Stop()
 			}
-			logging.VeryVerbose.Printf("new masters detected: %v", masters)
+			logging.Verbose.Printf("new masters detected: %v", masters)
 			res.SetMasters(masters)
 			res.Reload()
 		case err := <-errch:


### PR DESCRIPTION
The detection of new masters now results in a log line that is displayed even with a disabled verbose mode. 

The idea behind this change is that this event is important and not common thus it should be logged as such.