### PR TITLE
Added error message when no masters given.

### DIFF
--- a/records/state/client/cli.go
+++ b/records/state/client/cli.go
@@ -43,6 +43,8 @@ func LoadMasterStateTryAll(masters []string, stateLoader func(ip, port string) (
 
 	if len(masters) > 0 {
 		leader, masters = masters[0], masters[1:]
+	} else {
+		return sj, errors.New("no masters given to fetch state.json")
 	}
 
 	// Check if ZK leader is correct


### PR DESCRIPTION
We now return an error message if no masters have been given when
generating a new Mesos master state loader.