### PR TITLE
Ignore inactive frameworks

### DIFF
--- a/factories/fake.json
+++ b/factories/fake.json
@@ -213,6 +213,35 @@
              "user": "root"
         },
         {
+            "id":"1b4c4343-a8a1-48ca-a74c-4e24d7947303-0002",
+            "name":"marathon",
+            "pid":"scheduler-621043d2-ab95-448d-a5a9-970d475a8b4e@10.0.2.175:44369",
+            "capabilities":["TASK_KILLING_STATE","PARTITION_AWARE","REGION_AWARE"],
+            "hostname":"10.0.2.175",
+            "webui_url":"http:\/\/10.0.2.175:26074",
+            "active":false,
+            "connected":false,
+            "recovered":false,
+            "user":"root",
+            "failover_timeout":604800.0,
+            "checkpoint":true,
+            "registered_time":1519673766.85769,
+            "unregistered_time":0.0,
+            "principal":"marathon",
+            "resources":{
+              "disk":0.0,
+              "mem":0.0,
+              "gpus":0.0,
+              "cpus":0.0
+            },
+            "role":"marathon",
+            "tasks":[],
+            "unreachable_tasks":[],
+            "completed_tasks":[],
+            "offers":[],
+            "executors":[]
+        },
+        {
             "active": true,
             "checkpoint": true,
             "completed_tasks": [

--- a/records/generator.go
+++ b/records/generator.go
@@ -221,6 +221,9 @@ func (rg *RecordGenerator) InsertState(sj state.State, domain, ns, listener stri
 //     _framework._tcp.frameworkname.domain. // resolves to the driver port and IP of each framework
 func (rg *RecordGenerator) frameworkRecords(sj state.State, domain string, spec labels.Func) {
 	for _, f := range sj.Frameworks {
+		if !f.Active {
+			continue
+		}
 		host, port := f.HostPort()
 		if ips := hostToIPs(host); len(ips) > 0 {
 			fname := labels.DomainFrag(f.Name, labels.Sep, spec)

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -220,6 +220,7 @@ type Framework struct {
 	PID      PID    `json:"pid"`
 	Name     string `json:"name"`
 	Hostname string `json:"hostname"`
+	Active   bool   `json:"active"`
 }
 
 // HostPort returns the hostname and port where a framework's scheduler is


### PR DESCRIPTION
Current behavior of the record generator is to create A records for all frameworks even if `"active": false`. One specific scenario that this can be problematic is this:

1. Install marathon on marathon (MoM) DC/OS package with serviceID: `marathon`
2. `nslookup marathon.mesos` and note that there are now 2 A records for `marathon.mesos`
3. Uninstall MoM
4. `nslookup marathon.mesos` and note that there are still 2 A records for `marathon.mesos`, one of them invalid

This PR addresses this by ignoring inactive frameworks.