### PR TITLE
Moves mesos state endpoint from /state.json to /state

### DIFF
--- a/httpcli/iam/file.go
+++ b/httpcli/iam/file.go
@@ -12,7 +12,7 @@ import (
 // LoadFromFile reads an IAM Config from a file (JSON format) on the local filesystem.
 func LoadFromFile(filename string) (config Config, err error) {
 	var f *os.File
-	if f, err = os.Open(filename); err != nil {
+	if f, err = os.Open(filename); err != nil { // nolint: gosec
 		err = fmt.Errorf("failed to load IAM config from file %q: %+v", filename, err)
 		return
 	}

--- a/records/config.go
+++ b/records/config.go
@@ -113,9 +113,9 @@ type Config struct {
 // NewConfig return the default config of the resolver
 func NewConfig() Config {
 	return Config{
-		ZkDetectionTimeout:     30,
-		RefreshSeconds:         60,
-		TTL:                    60,
+		ZkDetectionTimeout: 30,
+		RefreshSeconds:     60,
+		TTL:                60,
 		SRVRecordDefaultWeight: 1,
 		Domain:                 "mesos",
 		Port:                   53,
@@ -313,7 +313,7 @@ func (c Config) log() {
 
 func readCACertFile(caCertFile string) (caPool *x509.CertPool, err error) {
 	var f *os.File
-	if f, err = os.Open(caCertFile); err != nil {
+	if f, err = os.Open(caCertFile); err != nil { // nolint: gosec
 		err = fmt.Errorf("CACertFile open failed: %v", err)
 		return
 	}

--- a/records/generator.go
+++ b/records/generator.go
@@ -145,7 +145,7 @@ func WithConfig(config Config) Option {
 		timeout       = httpcli.Timeout(time.Duration(config.StateTimeoutSeconds) * time.Second)
 		doer          = httpcli.New(config.MesosAuthentication, config.httpConfigMap, transport, timeout)
 		stateEndpoint = urls.Builder{}.With(
-			urls.Path("/master/state.json"),
+			urls.Path("/master/state"),
 			opt,
 		)
 	)
@@ -168,13 +168,13 @@ func NewRecordGenerator(options ...Option) *RecordGenerator {
 	return rg
 }
 
-// ParseState retrieves and parses the Mesos master /state.json and converts it
+// ParseState retrieves and parses the Mesos master /state and converts it
 // into DNS records.
 func (rg *RecordGenerator) ParseState(c Config, masters ...string) error {
 	// find master -- return if error
 	sj, err := rg.stateLoader(masters)
 	if err != nil {
-		logging.Error.Println("Failed to fetch state.json. Error: ", err)
+		logging.Error.Println("Failed to fetch state. Error: ", err)
 		return err
 	}
 	if sj.Leader == "" {

--- a/records/generator.go
+++ b/records/generator.go
@@ -3,7 +3,7 @@
 package records
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // nolint: gosec
 	"encoding/json"
 	"errors"
 	"net"
@@ -197,7 +197,7 @@ func (rg *RecordGenerator) ParseState(c Config, masters ...string) error {
 // zbase32: http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
 // is used to promote human-readable names
 func hashString(s string) string {
-	hash := sha1.Sum([]byte(s))
+	hash := sha1.Sum([]byte(s)) // nolint: gosec
 	return zbase32.EncodeToString(hash[:])[:5]
 }
 

--- a/records/state/client/cli.go
+++ b/records/state/client/cli.go
@@ -55,7 +55,7 @@ func LoadMasterStateTryAll(masters []string, stateLoader func(ip, port string) (
 			if sj, err = stateLoader(ip, port); err == nil {
 				return sj, nil
 			}
-			logging.Error.Println("Failed to fetch state.json from leader. Error: ", err)
+			logging.Error.Println("Failed to fetch state from leader. Error: ", err)
 			if len(masters) == 0 {
 				logging.Error.Println("No more masters to try, returning last error")
 				return sj, err
@@ -77,17 +77,17 @@ func LoadMasterStateTryAll(masters []string, stateLoader func(ip, port string) (
 		}
 
 		if sj, err = stateLoader(ip, port); err != nil {
-			logging.Error.Println("Failed to fetch state.json - trying next one. Error: ", err)
+			logging.Error.Println("Failed to fetch state - trying next one. Error: ", err)
 			continue
 		}
 		return sj, nil
 	}
 
-	logging.Error.Println("No more masters eligible for state.json query, returning last error")
+	logging.Error.Println("No more masters eligible for state query, returning last error")
 	return sj, err
 }
 
-// LoadMasterStateFailover catches an attempt to load state.json from a mesos master.
+// LoadMasterStateFailover catches an attempt to load state from a mesos master.
 // Attempts can fail from due to a down server or if contacting a mesos master secondary.
 // It reloads from a different master if the contacted master is a secondary.
 func LoadMasterStateFailover(initialMasterIP string, stateLoader func(ip string) (state.State, error)) (state.State, error) {
@@ -112,13 +112,13 @@ func LoadMasterStateFailover(initialMasterIP string, stateLoader func(ip string)
 		}
 		return sj, nil
 	}
-	err = errors.New("Fetched state.json does not contain leader information")
+	err = errors.New("Fetched state does not contain leader information")
 	return sj, err
 }
 
-// LoadMasterState loads state.json from mesos master
+// LoadMasterState loads state from mesos master
 func LoadMasterState(client httpcli.Doer, stateEndpoint urls.Builder, ip, port string, unmarshal Unmarshaler) (sj state.State, _ error) {
-	// REFACTOR: state.json security
+	// REFACTOR: state security
 
 	u := url.URL(stateEndpoint.With(urls.Host(net.JoinHostPort(ip, port))))
 

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mesosphere/mesos-dns/records/state/upid"
 )
 
-// Resources holds resources as defined in the /state.json Mesos HTTP endpoint.
+// Resources holds resources as defined in the /state Mesos HTTP endpoint.
 type Resources struct {
 	PortRanges string `json:"ports"`
 }
@@ -48,13 +48,13 @@ func (r Resources) Ports() []string {
 	return yports
 }
 
-// Label holds a label as defined in the /state.json Mesos HTTP endpoint.
+// Label holds a label as defined in the /state Mesos HTTP endpoint.
 type Label struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-// Status holds a task status as defined in the /state.json Mesos HTTP endpoint.
+// Status holds a task status as defined in the /state Mesos HTTP endpoint.
 type Status struct {
 	Timestamp       float64         `json:"timestamp"`
 	State           string          `json:"state"`
@@ -62,14 +62,14 @@ type Status struct {
 	ContainerStatus ContainerStatus `json:"container_status,omitempty"`
 }
 
-// ContainerStatus holds container metadata as defined in the /state.json
+// ContainerStatus holds container metadata as defined in the /state
 // Mesos HTTP endpoint.
 type ContainerStatus struct {
 	NetworkInfos []NetworkInfo `json:"network_infos,omitempty"`
 }
 
 // NetworkInfo holds the network configuration for a single interface
-// as defined in the /state.json Mesos HTTP endpoint.
+// as defined in the /state Mesos HTTP endpoint.
 type NetworkInfo struct {
 	IPAddresses []IPAddress `json:"ip_addresses,omitempty"`
 	// back-compat with 0.25 IPAddress format
@@ -77,12 +77,12 @@ type NetworkInfo struct {
 }
 
 // IPAddress holds a single IP address configured on an interface,
-// as defined in the /state.json Mesos HTTP endpoint.
+// as defined in the /state Mesos HTTP endpoint.
 type IPAddress struct {
 	IPAddress string `json:"ip_address,omitempty"`
 }
 
-// Task holds a task as defined in the /state.json Mesos HTTP endpoint.
+// Task holds a task as defined in the /state Mesos HTTP endpoint.
 type Task struct {
 	FrameworkID   string   `json:"framework_id"`
 	ID            string   `json:"id"`
@@ -97,7 +97,7 @@ type Task struct {
 	SlaveIPs []string `json:"-"`
 }
 
-// HasDiscoveryInfo return whether the DiscoveryInfo was provided in the state.json
+// HasDiscoveryInfo return whether the DiscoveryInfo was provided in the state
 func (t *Task) HasDiscoveryInfo() bool {
 	return t.DiscoveryInfo.Name != ""
 }
@@ -184,7 +184,7 @@ func mesosIPs(t *Task) []string {
 
 // statusIPs returns the latest running status IPs extracted with the given src
 func statusIPs(st []Status, src func(*Status) []string) []string {
-	// the state.json we extract from mesos makes no guarantees re: the order
+	// the state we extract from mesos makes no guarantees re: the order
 	// of the task statuses so we should check the timestamps to avoid problems
 	// down the line. we can't rely on seeing the same sequence. (@joris)
 	// https://github.com/apache/mesos/blob/0.24.0/src/slave/slave.cpp#L5226-L5238
@@ -214,7 +214,7 @@ func labels(key string) func(*Status) []string {
 	}
 }
 
-// Framework holds a framework as defined in the /state.json Mesos HTTP endpoint.
+// Framework holds a framework as defined in the /state Mesos HTTP endpoint.
 type Framework struct {
 	Tasks    []Task `json:"tasks"`
 	PID      PID    `json:"pid"`
@@ -231,7 +231,7 @@ func (f Framework) HostPort() (string, string) {
 	return f.Hostname, ""
 }
 
-// Slave holds a slave as defined in the /state.json Mesos HTTP endpoint.
+// Slave holds a slave as defined in the /state Mesos HTTP endpoint.
 type Slave struct {
 	ID       string `json:"id"`
 	Hostname string `json:"hostname"`
@@ -247,14 +247,14 @@ func (p *PID) UnmarshalJSON(data []byte) (err error) {
 	return err
 }
 
-// State holds the state defined in the /state.json Mesos HTTP endpoint.
+// State holds the state defined in the /state Mesos HTTP endpoint.
 type State struct {
 	Frameworks []Framework `json:"frameworks"`
 	Slaves     []Slave     `json:"slaves"`
 	Leader     string      `json:"leader"`
 }
 
-// DiscoveryInfo holds the discovery meta data for a task defined in the /state.json Mesos HTTP endpoint.
+// DiscoveryInfo holds the discovery meta data for a task defined in the /state Mesos HTTP endpoint.
 type DiscoveryInfo struct {
 	Visibilty   string `json:"visibility"`
 	Version     string `json:"version,omitempty"`
@@ -269,7 +269,7 @@ type DiscoveryInfo struct {
 	} `json:"ports"`
 }
 
-// DiscoveryPort holds a port for a task defined in the /state.json Mesos HTTP endpoint.
+// DiscoveryPort holds a port for a task defined in the /state Mesos HTTP endpoint.
 type DiscoveryPort struct {
 	Protocol string `json:"protocol"`
 	Number   int    `json:"number"`

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -783,7 +783,9 @@ func panicRecover(f func(w dns.ResponseWriter, r *dns.Msg)) func(w dns.ResponseW
 			if rec := recover(); rec != nil {
 				m := new(dns.Msg)
 				m.SetRcode(r, 2)
-				_ = w.WriteMsg(m)
+				if err := w.WriteMsg(m); err != nil {
+					logging.Error.Println(err)
+				}
 				logging.Error.Println(rec)
 			}
 		}()


### PR DESCRIPTION
Mesos has deprecated/removed the `/state.json` endpoint and has
replaced it with `/state`. This patch updates the url path from
`/state.json` to `/state`

jira: DCOS_OSS-3941