### PR TITLE
Add container address to DNS A record. Such as nginx.marathon.contain…

### DIFF
--- a/records/generator.go
+++ b/records/generator.go
@@ -394,6 +394,7 @@ type context struct {
 	slaveID  string
 	taskIPs  []net.IP
 	slaveIPs []string
+	containerIP string
 }
 
 func (rg *RecordGenerator) taskRecord(task state.Task, f state.Framework, domain string, spec labels.Func, ipSources []string, enumFW *EnumerableFramework) {
@@ -409,6 +410,7 @@ func (rg *RecordGenerator) taskRecord(task state.Task, f state.Framework, domain
 		slaveIDTail(task.SlaveID),
 		task.IPs(ipSources...),
 		task.SlaveIPs,
+		task.ContainerIPAddress(),
 	}
 
 	// use DiscoveryInfo name if defined instead of task name
@@ -453,6 +455,9 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 			rg.insertTaskRR(arec+".slave"+tail, sIPStr, A, enumTask)
 			rg.insertTaskRR(canonical+".slave"+tail, sIPStr, A, enumTask)
 		}
+	}
+	if ctx.containerIP != "" {
+		rg.insertTaskRR(arec+".container"+tail, ctx.containerIP, A, enumTask)
 	}
 
 	// recordName generates records for ctx.taskName, given some generation chain

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -128,6 +128,15 @@ func (t *Task) IPs(srcs ...string) (ips []net.IP) {
 	return ips
 }
 
+func (t *Task) ContainerIPAddress() string{
+	for _, status := range(t.Statuses) {
+		if status.State == "TASK_RUNNING" {
+			return status.ContainerStatus.NetworkInfos[0].IPAddresses[0].IPAddress
+		}
+	}
+	return ""
+}
+
 // sources maps the string representation of IP sources to their functions.
 var sources = map[string]func(*Task) []string{
 	"host":    hostIPs,


### PR DESCRIPTION
Some program, such as Envoy, needs container address to route requests.
So I add container address DNS A record to solve it.

e.g.
nginx.marathon.mesos  resolve to host ip.
nginx.marathon.container.mesos  resolve to container ip.