### PR TITLE
Fix new metalinter complaints.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   pre:
-    - wget https://storage.googleapis.com/golang/go1.11.2.linux-amd64.tar.gz
-    - tar zxvf go1.11.2.linux-amd64.tar.gz
+    - wget https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz
+    - tar zxvf go1.11.5.linux-amd64.tar.gz
   environment:
     GOROOT: ${HOME}/go
     GOPATH: ${HOME}/gopath

--- a/httpcli/config.go
+++ b/httpcli/config.go
@@ -21,8 +21,8 @@ var (
 // AuthNone, et al. represent the complete set of supported authentication mechanisms
 const (
 	AuthNone  AuthMechanism = ""      // AuthNone specifies no authentication mechanism
-	AuthBasic               = "basic" // AuthBasic specifies to use HTTP Basic
-	AuthIAM                 = "iam"   // AuthIAM specifies to use IAM / JDK authentication
+	AuthBasic AuthMechanism = "basic" // AuthBasic specifies to use HTTP Basic
+	AuthIAM   AuthMechanism = "iam"   // AuthIAM specifies to use IAM / JDK authentication
 )
 
 var (

--- a/records/labels/labels_test.go
+++ b/records/labels/labels_test.go
@@ -40,22 +40,23 @@ func TestRFC952(t *testing.T) {
 	t.Parallel()
 
 	testFunc(t, "RFC952", RFC952, cases{
-		"4abc123":                                                        "abc123",
-		"-4abc123":                                                       "abc123",
-		"fd%gsf---gs7-f$gs--d7fddg-123":                                  "fdgsf---gs7-fgs--d7fddg1",
-		"89fdgsf---gs7-fgs--d7fddg-123":                                  "fdgsf---gs7-fgs--d7fddg1",
-		"89fdgsf---gs7-fgs--d7fddg---123":                                "fdgsf---gs7-fgs--d7fddg1",
-		"89fdgsf---gs7-fgs--d7fddg-":                                     "fdgsf---gs7-fgs--d7fddg",
-		"chronos with a space AND MIXED CASE-2.0.1":                      "chronoswithaspaceandmixe",
-		"chronos with a space AND----------MIXED--":                      "chronoswithaspaceandmixe",
+		"4abc123":                                   "abc123",
+		"-4abc123":                                  "abc123",
+		"fd%gsf---gs7-f$gs--d7fddg-123":             "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-123":             "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg---123":           "fdgsf---gs7-fgs--d7fddg1",
+		"89fdgsf---gs7-fgs--d7fddg-":                "fdgsf---gs7-fgs--d7fddg",
+		"chronos with a space AND MIXED CASE-2.0.1": "chronoswithaspaceandmixe",
+		"chronos with a space AND----------MIXED--": "chronoswithaspaceandmixe",
 		"hello--------------------------------------------------------f": "hellof",
 	})
 
 	quickCheckFunc(t, "RFC952", RFC952, cases{
 		"doesn't start with numbers or dashes": func(s string) bool {
-			return 0 != strings.IndexFunc(RFC952(s), func(r rune) bool {
+			val := strings.IndexFunc(RFC952(s), func(r rune) bool {
 				return r == '-' || (r >= '0' && r <= '9')
 			})
+			return val != 0
 		},
 		"isn't longer than 24 chars": func(s string) bool {
 			return len(RFC952(s)) <= 24
@@ -74,12 +75,12 @@ func TestRFC1123(t *testing.T) {
 	t.Parallel()
 
 	testFunc(t, "RFC1123", RFC1123, cases{
-		"4abc123":                                                                "4abc123",
-		"-4abc123":                                                               "4abc123",
-		"89fdgsf---gs7-fgs--d7fddg-123":                                          "89fdgsf---gs7-fgs--d7fddg-123",
-		"89fdgsf---gs7-fgs--d7fddg---123":                                        "89fdgsf---gs7-fgs--d7fddg---123",
-		"89fdgsf---gs7-fgs--d7fddg-":                                             "89fdgsf---gs7-fgs--d7fddg",
-		"fd%gsf---gs7-f$gs--d7fddg-123":                                          "fdgsf---gs7-fgs--d7fddg-123",
+		"4abc123":                         "4abc123",
+		"-4abc123":                        "4abc123",
+		"89fdgsf---gs7-fgs--d7fddg-123":   "89fdgsf---gs7-fgs--d7fddg-123",
+		"89fdgsf---gs7-fgs--d7fddg---123": "89fdgsf---gs7-fgs--d7fddg---123",
+		"89fdgsf---gs7-fgs--d7fddg-":      "89fdgsf---gs7-fgs--d7fddg",
+		"fd%gsf---gs7-f$gs--d7fddg-123":   "fdgsf---gs7-fgs--d7fddg-123",
 		"fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123":   "fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891",
 		"$$fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-123":   "fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891",
 		"%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123": "fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891",
@@ -129,20 +130,20 @@ func testDomainFrag(t *testing.T, id string, label Func, special cases) {
 
 func testFunc(t *testing.T, id string, label Func, special cases) {
 	testTransform(t, id, label, special, cases{
-		"":                                                                 "",
-		"a":                                                                "a",
-		"-":                                                                "",
-		"a---":                                                             "a",
-		"---a---":                                                          "a",
-		"---a---b":                                                         "a---b",
-		"a.b.c.d.e":                                                        "a-b-c-d-e",
-		"a.c.d_de.":                                                        "a-c-d-de",
-		"abc123":                                                           "abc123",
-		"-abc123":                                                          "abc123",
-		"abc123-":                                                          "abc123",
-		"abc-123":                                                          "abc-123",
-		"abc--123":                                                         "abc--123",
-		"r29f.dev.angrypigs":                                               "r29f-dev-angrypigs",
+		"":                   "",
+		"a":                  "a",
+		"-":                  "",
+		"a---":               "a",
+		"---a---":            "a",
+		"---a---b":           "a---b",
+		"a.b.c.d.e":          "a-b-c-d-e",
+		"a.c.d_de.":          "a-c-d-de",
+		"abc123":             "abc123",
+		"-abc123":            "abc123",
+		"abc123-":            "abc123",
+		"abc-123":            "abc-123",
+		"abc--123":           "abc--123",
+		"r29f.dev.angrypigs": "r29f-dev-angrypigs",
 		"hello----------------------------------------------------------f": "hellof",
 	})
 }

--- a/records/state/client/cli.go
+++ b/records/state/client/cli.go
@@ -112,7 +112,7 @@ func LoadMasterStateFailover(initialMasterIP string, stateLoader func(ip string)
 		}
 		return sj, nil
 	}
-	err = errors.New("Fetched state does not contain leader information")
+	err = errors.New("fetched state does not contain leader information")
 	return sj, err
 }
 

--- a/records/state/upid/upid.go
+++ b/records/state/upid/upid.go
@@ -38,7 +38,7 @@ func Parse(input string) (*UPID, error) {
 
 	splits := strings.Split(input, "@")
 	if len(splits) != 2 {
-		return nil, fmt.Errorf("Expect one `@' in the input")
+		return nil, fmt.Errorf("expect one `@' in the input")
 	}
 	upid.ID = splits[0]
 

--- a/records/validation.go
+++ b/records/validation.go
@@ -12,10 +12,10 @@ var dnsValidationRegex = regexp.MustCompile(`^[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$`)
 
 func validateEnabledServices(c *Config) error {
 	if !c.DNSOn && !c.HTTPOn {
-		return fmt.Errorf("Either DNS or HTTP server should be on")
+		return fmt.Errorf("either DNS or HTTP server should be on")
 	}
 	if len(c.Masters) == 0 && c.Zk == "" {
-		return fmt.Errorf("Specify Mesos masters or Zookeeper in config.json")
+		return fmt.Errorf("specify Mesos masters or Zookeeper in config.json")
 	}
 	return nil
 }
@@ -25,7 +25,7 @@ func validateEnabledServices(c *Config) error {
 // returns nil if the masters list is empty, or else all masters in the list are valid.
 func validateMasters(ms []string) error {
 	if err := validateUniqueStrings(ms, normalizeMaster); err != nil {
-		return fmt.Errorf("Error validating masters: %v", err)
+		return fmt.Errorf("error validating masters: %v", err)
 	}
 	return nil
 }
@@ -33,14 +33,14 @@ func validateMasters(ms []string) error {
 func normalizeMaster(hostPort string) (string, error) {
 	host, port, err := net.SplitHostPort(hostPort)
 	if err != nil {
-		return "", fmt.Errorf("Illegal host:port specified: %v. Error: %v", hostPort, err)
+		return "", fmt.Errorf("illegal host:port specified: %v. Error: %v", hostPort, err)
 	}
 	if ip := net.ParseIP(host); ip != nil {
 		//TODO(jdef) distinguish between intended hostnames and invalid ip addresses
 		host = ip.String()
 	}
 	if !validPortString(port) {
-		return "", fmt.Errorf("Illegal host:port specified: %v", hostPort)
+		return "", fmt.Errorf("illegal host:port specified: %v", hostPort)
 	}
 	return net.JoinHostPort(host, port), nil
 }
@@ -50,14 +50,14 @@ func normalizeMaster(hostPort string) (string, error) {
 // returns nil if the resolver list is empty, or else all resolvers in the list are valid.
 func validateResolvers(rs []string) error {
 	if err := validateUniqueStrings(rs, normalizeResolver); err != nil {
-		return fmt.Errorf("Error validating resolvers: %v", err)
+		return fmt.Errorf("error validating resolvers: %v", err)
 	}
 	return nil
 }
 
 func validateDomainName(domain string) error {
 	if !dnsValidationRegex.MatchString(domain) {
-		return fmt.Errorf("Invalid domain name: %s", domain)
+		return fmt.Errorf("invalid domain name: %s", domain)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func validateZoneResolvers(zrs map[string][]string, mesosDomain string) (
 
 	for domain, rs := range zrs {
 		if len(rs) == 0 {
-			return fmt.Errorf("ZoneResolver %v is empty", domain)
+			return fmt.Errorf("field ZoneResolver %v is empty", domain)
 		}
 		err = validateDomainName(domain)
 		if err != nil {
@@ -81,7 +81,7 @@ func validateZoneResolvers(zrs map[string][]string, mesosDomain string) (
 			return
 		}
 		if domain == mesosDomain {
-			return fmt.Errorf("Can't specify ZoneResolver for Mesos domain (%v)",
+			return fmt.Errorf("can't specify ZoneResolver for Mesos domain (%v)",
 				mesosDomain)
 		}
 		allDomains = append(allDomains, "."+domain)
@@ -91,7 +91,7 @@ func validateZoneResolvers(zrs map[string][]string, mesosDomain string) (
 		for _, b := range allDomains {
 			if (a != b) &&
 				strings.HasSuffix(a, b) {
-				return fmt.Errorf("Ambiguous zone resolvers: %v is masked by %v",
+				return fmt.Errorf("ambiguous zone resolvers: %v is masked by %v",
 					a, b)
 			}
 		}
@@ -108,11 +108,11 @@ func normalizeResolver(hostPort string) (string, error) {
 	if ip := net.ParseIP(host); ip != nil {
 		host = ip.String()
 	} else {
-		return "", fmt.Errorf("Illegal ip specified: %v", host)
+		return "", fmt.Errorf("illegal ip specified: %v", host)
 	}
 
 	if !validPortString(port) {
-		return "", fmt.Errorf("Illegal host:port specified: %v", hostPort)
+		return "", fmt.Errorf("illegal host:port specified: %v", hostPort)
 	}
 	return net.JoinHostPort(host, port), nil
 }
@@ -127,7 +127,7 @@ func validateUniqueStrings(strings []string, normalize func(string) (string, err
 			return err
 		}
 		if _, found := valid[normalized]; found {
-			return fmt.Errorf("Duplicate found: %v", str)
+			return fmt.Errorf("duplicate found: %v", str)
 		}
 		valid[normalized] = struct{}{}
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -154,7 +154,7 @@ func (res *Resolver) Serve(proto string) (<-chan struct{}, <-chan error) {
 		defer close(errCh)
 		err := server.ListenAndServe()
 		if err != nil {
-			errCh <- fmt.Errorf("Failed to setup %q server: %v", proto, err)
+			errCh <- fmt.Errorf("failed to setup %q server: %v", proto, err)
 		} else {
 			logging.Error.Printf("Not listening/serving any more requests.")
 		}
@@ -613,7 +613,7 @@ func (res *Resolver) LaunchHTTP() <-chan error {
 		defer func() { errCh <- err }()
 
 		if err = http.ListenAndServe(listenAddress, nil); err != nil {
-			err = fmt.Errorf("Failed to setup http server: %v", err)
+			err = fmt.Errorf("failed to setup http server: %v", err)
 		} else {
 			logging.Error.Println("Not serving http requests any more.")
 		}


### PR DESCRIPTION
metalinter was updated w/ some new checks and it's triggered mesos-dns CI failures. this PR addresses those complaints, and also bumps golang to the latest 1.11.x release.