### PR TITLE
fix: add WaitGroup to accurately measure elapsed time of benchmark

### DIFF
--- a/tools/main.go
+++ b/tools/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"sync"
 
 	"github.com/miekg/dns"
 )
@@ -32,14 +33,19 @@ func query(dom string) {
 }
 
 func main() {
+	wg := &sync.WaitGroup{}
 	start := time.Now()
-
 	cnt := 10000
 
 	for i := 0; i < cnt; i++ {
-		go query("bob.mesos")
+		wg.Add(1)
+		go func() {
+			query("bob.mesos")
+			wg.Done()
+		}()
 	}
 
+	wg.Wait()
 	elapsed := time.Since(start)
 	log.Printf("benching took %s", elapsed)
 	log.Printf("doing %d/%v rps", cnt, elapsed)


### PR DESCRIPTION
Howdy!

I took a look through this repository and found a small error. I figured in the spirit of saying "hello 👋" I'd ship a fix. 

Thanks,
Jared


    What version of the project are you using?

Master repo - dcos 1.12

    What operating system and processor architecture are you using?

Debian/Linux

    What did you do?

Tried to test a benchmark

    What did you expect to see?

The tool is asserting that it is benchmarking queries.

    What did you see instead?

The tool simply iterates a for loop issuing 10k goroutines, which promptly close. The test isn't performing as desired.
