### PR TITLE
Updated markdown processor from redcarpet to commonmark.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ sass:
 baseurl: "/mesos-dns"
 highlighter: pygments
 lsi: false
-markdown: redcarpet
+markdown: commonmark
 redcarpet:
   extensions: [with_toc_data, tables]
 safe: true


### PR DESCRIPTION
Redcarpet processor is no longer recommended per https://help.github.com/en/github/working-with-github-pages/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll.