### PR TITLE
Updated site highlighter from pygments to rogue.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ sass:
   style: :compressed
 
 baseurl: "/mesos-dns"
-highlighter: pygments
+highlighter: rouge
 lsi: false
 markdown: commonmark
 redcarpet:


### PR DESCRIPTION
This is to suppress warning from GitHub https://help.github.com/en/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#fixing-highlighting-errors