### PR TITLE
Remove limit of one IP address per A record, modify Task.IPs behavior…

### DIFF
--- a/factories/fake.json
+++ b/factories/fake.json
@@ -83,6 +83,15 @@
                                         "ip_addresses": [
                                             {
                                                 "protocol": "IPv4",
+                                                "ip_address": "12.0.1.3"
+                                            }
+                                        ],
+                                        "name": "dcos6"
+                                    },
+                                    {
+                                        "ip_addresses": [
+                                            {
+                                                "protocol": "IPv4",
                                                 "ip_address": "12.0.1.2"
                                             },
                                             {

--- a/records/generator.go
+++ b/records/generator.go
@@ -567,7 +567,7 @@ func rrsKindForIPStr(ip string) rrsKind {
 
 // hostToIPs attempts to parse a hostname into an ip.
 // If that doesn't work it will perform a lookup and try to
-// find all ipv4 and ipv6 addresses for teh hostname.
+// find all ipv4 and ipv6 addresses for the hostname.
 func hostToIPs(hostname string) (ips []net.IP) {
 	if ip := net.ParseIP(hostname); ip != nil {
 		ips = []net.IP{ip}

--- a/records/generator.go
+++ b/records/generator.go
@@ -434,14 +434,12 @@ func (rg *RecordGenerator) taskContextRecord(ctx context, task state.Task, f sta
 	canonical := ctx.taskName + "-" + ctx.taskID + "-" + ctx.slaveID + "." + fname
 	arec := ctx.taskName + "." + fname
 
-	// Only use the first ipv4 and first ipv6 found in sources
-	tIPs := ipsTo4And6(ctx.taskIPs)
-	for _, tIP := range tIPs {
+	// Use the IPs from the first populated source
+	for _, tIP := range ctx.taskIPs {
 		rg.insertTaskRR(arec+tail, tIP.String(), rrsKindForIP(tIP), enumTask)
 		rg.insertTaskRR(canonical+tail, tIP.String(), rrsKindForIP(tIP), enumTask)
 	}
 
-	// slaveIPs already only has at most one ipv4 and one ipv6
 	for _, sIPStr := range ctx.slaveIPs {
 		if sIP := net.ParseIP(sIPStr); sIP != nil {
 			rg.insertTaskRR(arec+".slave"+tail, sIP.String(), rrsKindForIP(sIP), enumTask)
@@ -567,41 +565,14 @@ func rrsKindForIPStr(ip string) rrsKind {
 	panic("unable to parse ip: " + ip)
 }
 
-// ipsTo4And6 returns a list with at most 1 ipv4 and 1 ipv6
-// from a list of IPs
-func ipsTo4And6(allIPs []net.IP) (ips []net.IP) {
-	var ipv4, ipv6 net.IP
-	for _, ip := range allIPs {
-		if ipv4 != nil && ipv6 != nil {
-			break
-		} else if t4 := ip.To4(); t4 != nil {
-			if ipv4 == nil {
-				ipv4 = t4
-			}
-		} else if t6 := ip.To16(); t6 != nil {
-			if ipv6 == nil {
-				ipv6 = t6
-			}
-		}
-	}
-	ips = []net.IP{}
-	if ipv4 != nil {
-		ips = append(ips, ipv4)
-	}
-	if ipv6 != nil {
-		ips = append(ips, ipv6)
-	}
-	return
-}
-
 // hostToIPs attempts to parse a hostname into an ip.
 // If that doesn't work it will perform a lookup and try to
-// find one ipv4 and one ipv6 in the results.
+// find all ipv4 and ipv6 addresses for teh hostname.
 func hostToIPs(hostname string) (ips []net.IP) {
 	if ip := net.ParseIP(hostname); ip != nil {
 		ips = []net.IP{ip}
 	} else if allIPs, err := net.LookupIP(hostname); err == nil {
-		ips = ipsTo4And6(allIPs)
+		ips = allIPs
 	}
 	if len(ips) == 0 {
 		logging.VeryVerbose.Printf("cannot translate hostname %q into an ipv4 or ipv6 address", hostname)

--- a/records/generator_test.go
+++ b/records/generator_test.go
@@ -328,7 +328,7 @@ func TestInsertState(t *testing.T) {
 		{rgMesos.AAAAs, "toy-store.ipv6-framework.mesos.", []string{"2001:db8::1"}},
 		{rgMesos.AAAAs, "toy-store.ipv6-framework.slave.mesos.", []string{"2001:db8::1"}},
 
-		{rgNetinfo.As, "toy-store.ipv6-framework.mesos.", []string{"12.0.1.2"}},
+		{rgNetinfo.As, "toy-store.ipv6-framework.mesos.", []string{"12.0.1.3", "12.0.1.2"}},
 
 		{rgNetinfo.AAAAs, "toy-store.ipv6-framework.mesos.", []string{"fd01:b::1:8000:2"}},
 		{rgNetinfo.AAAAs, "toy-store.ipv6-framework.slave.mesos.", []string{"2001:db8::1"}},

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -111,7 +111,7 @@ func (t *Task) IP(srcs ...string) string {
 }
 
 // IPs returns a slice of IPs sourced from the given sources with ascending
-// priority. Returns only the IPs from the first successful source.
+// priority. Returns only the IPs from the first populated source.
 func (t *Task) IPs(srcs ...string) (ips []net.IP) {
 	if t == nil {
 		return nil

--- a/records/state/state.go
+++ b/records/state/state.go
@@ -111,7 +111,7 @@ func (t *Task) IP(srcs ...string) string {
 }
 
 // IPs returns a slice of IPs sourced from the given sources with ascending
-// priority.
+// priority. Returns only the IPs from the first successful source.
 func (t *Task) IPs(srcs ...string) (ips []net.IP) {
 	if t == nil {
 		return nil
@@ -123,6 +123,10 @@ func (t *Task) IPs(srcs ...string) (ips []net.IP) {
 					ips = append(ips, ip)
 				}
 			}
+		}
+		// Return IPs from first populated source
+		if len(ips) > 0 {
+			return ips
 		}
 	}
 	return ips
@@ -144,7 +148,7 @@ func hostIPs(t *Task) []string { return t.SlaveIPs }
 // []Status.ContainerStatus.[]NetworkInfos.[]IPAddresses.IPAddress
 func networkInfoIPs(t *Task) []string {
 	return statusIPs(t.Statuses, func(s *Status) []string {
-		ips := make([]string, len(s.ContainerStatus.NetworkInfos))
+		ips := []string{}
 		for _, netinfo := range s.ContainerStatus.NetworkInfos {
 			if len(netinfo.IPAddresses) > 0 {
 				// In v0.26, we use the IPAddresses field.

--- a/records/state/state_test.go
+++ b/records/state/state_test.go
@@ -86,13 +86,21 @@ func TestTask_IPs(t *testing.T) {
 			srcs: []string{"netinfo"},
 			want: ips("1.2.4.8"),
 		},
-		{ // source order
+		{ // source order host
 			Task: task(
 				slaveIPs("2.3.4.5"),
 				statuses(status(state("TASK_RUNNING"), netinfos(netinfo("1.2.3.4", "fd01:b::1:8000:2")))),
 			),
 			srcs: []string{"host", "netinfo"},
-			want: ips("2.3.4.5", "1.2.3.4", "fd01:b::1:8000:2"),
+			want: ips("2.3.4.5"),
+		},
+		{ // source order netinfo
+			Task: task(
+				slaveIPs("2.3.4.5"),
+				statuses(status(state("TASK_RUNNING"), netinfos(netinfo("1.2.3.4", "fd01:b::1:8000:2")))),
+			),
+			srcs: []string{"netinfo", "host"},
+			want: ips("1.2.3.4", "fd01:b::1:8000:2"),
 		},
 		{ // statuses state
 			Task: task(


### PR DESCRIPTION
… to return only IPs from first populated source

Addresses https://github.com/mesosphere/mesos-dns/issues/541

* Added second network_infos to a task in `factories/fake.json`
* Added corresponding test in `records/generator_test.go`
* Removed `ipsTo4And6` in `records/generator.go`, it was unnecessarily limiting IP lists to a single ipv4 and ipv6 address for no good reason other than to perhaps avoid creating A records for more than one source
* Modified behavior of `Task.IPs` in `records/state/state.go` such that it returns all ip addresses from the first populated configured source
    * The previous behavior was to return all available IP addresses from all configured sources. These additional IPs were never used, because the list was always limited to a single ipv4 and ipv6 address.
* Updated a test in `records/state/state_test.go` to pass with the new `Task.IPs` behavior